### PR TITLE
add a default value that should be used for swtbot tests of gemoc

### DIFF
--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/WorkspaceTestHelper.xtend
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/WorkspaceTestHelper.xtend
@@ -66,7 +66,16 @@ class WorkspaceTestHelper {
 		
 	public static final String CMD_PROJECT_CLEAN = "org.eclipse.ui.project.cleanAction"	
 	
+	
+	/**
+	 * Value to use by default for SWTBotPreferences.TIMEOUT 
+	 * It must be used for any GEMOC test using swtbot 
+	 * we should increase this value up to the value where we don't have any false failed tests
+	 */ 
+	public static final int SWTBotPreferencesTIMEOUT_4_GEMOC = 8000;
+	
 	def void init() {
+		
 		Display.^default.syncExec(new Runnable(){
 				override run() {
 					PlatformUI::workbench.showPerspective(XDSMLFrameworkUI.ID_PERSPECTIVE, PlatformUI.workbench.activeWorkbenchWindow)


### PR DESCRIPTION
set a central value that should be used for all SWTBot based test.

this should avoid invalid failed tests due to CI server load

this PR complements PR https://github.com/eclipse/gemoc-studio/pull/36