### PR TITLE
[Debug/Engine] Replace MSEOccurence" with "Step" when possible

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IGemocDebugger.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IGemocDebugger.java
@@ -16,11 +16,12 @@ import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 
 import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
 
 public interface IGemocDebugger extends IEngineAddon {
 
-	public abstract void addPredicateBreak(BiPredicate<IExecutionEngine, MSEOccurrence> predicate);
+	public abstract void addPredicateBreak(BiPredicate<IExecutionEngine, Step<?>> predicate);
 
-	public abstract void addPredicateBreakpoint(BiPredicate<IExecutionEngine, MSEOccurrence> predicate);
+	public abstract void addPredicateBreakpoint(BiPredicate<IExecutionEngine, Step<?>> predicate);
 
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -34,17 +34,17 @@ import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 
-
-
 /**
- * Common implementation of {@link IExecutionEngine}.
- * It provides the following services:
+ * Common implementation of {@link IExecutionEngine}. It provides the following
+ * services:
  * <ul>
- * <li>a basic implementation of the notification for the engine addons ({@link IEngineAddon}).</li>
+ * <li>a basic implementation of the notification for the engine addons
+ * ({@link IEngineAddon}).</li>
  * <li>registration into the engine registry.</li>
  * <li>basic step service (with transaction)</li>
  * </ul>
  * This class is intended to be subclassed.
+ * 
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
@@ -73,7 +73,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	abstract protected void performInitialize(IExecutionContext executionContext);
 
 	abstract protected void beforeStart();
-	
+
 	abstract protected void finishDispose();
 
 	@Override
@@ -100,9 +100,8 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see
-	 * org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#getEngineStatus
-	 * ()
+	 * @see org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#
+	 * getEngineStatus ()
 	 */
 	@Override
 	public final EngineStatus getEngineStatus() {
@@ -121,9 +120,6 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 			Activator.getDefault().gemocRunningEngineRegistry.unregisterEngine(getName());
 		}
 	}
-
-	
-	
 
 	public String getName() {
 		return engineKindName() + " " + _executionContext.getRunConfiguration().getExecutedModelURI();
@@ -158,7 +154,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 			}
 		}
 	}
-	
+
 	protected void notifyEngineInitialized() {
 		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
 			try {
@@ -241,8 +237,8 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	 * (non-Javadoc)
 	 * 
 	 * @see
-	 * org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#hasAddon(java.
-	 * lang.Class)
+	 * org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#hasAddon(
+	 * java. lang.Class)
 	 */
 	@Override
 	public final <T extends IEngineAddon> boolean hasAddon(Class<T> type) {
@@ -257,8 +253,8 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	 * (non-Javadoc)
 	 * 
 	 * @see
-	 * org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#getAddon(java.
-	 * lang.Class)
+	 * org.eclipse.gemoc.executionframework.engine.core.IExecutionEngine#getAddon(
+	 * java. lang.Class)
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
@@ -320,7 +316,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 			thread.start();
 		}
 	}
-	
+
 	@Override
 	public final void startSynchronous() {
 		try {
@@ -383,7 +379,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 				Throwable realT = t.getStatus().getException();
 
 				// And we put it inside our own sort of exception, as a cause
-				SequentialExecutionException enclosingException = new SequentialExecutionException(getCurrentMSEOccurrence(), realT);
+				SequentialExecutionException enclosingException = new SequentialExecutionException(getCurrentStep(), realT);
 				enclosingException.initCause(realT);
 				throw enclosingException;
 			}
@@ -392,26 +388,24 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	}
 
 	@Override
-	public final Deque<MSEOccurrence> getCurrentStack() {
-		Deque<MSEOccurrence> result = new ArrayDeque<MSEOccurrence>();
-		for (Step<?> ls : currentSteps) {
-			result.add(ls.getMseoccurrence());
-		}
-		return result;
+	public final Deque<Step<?>> getCurrentStack() {
+		return currentSteps;
 	}
 
 	private EMFCommandTransaction createTransaction(InternalTransactionalEditingDomain editingDomain, RecordingCommand command) {
 		return new EMFCommandTransaction(command, editingDomain, null);
 	}
 
-
-	/* (non-Javadoc)
-	 * @see org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine#getCurrentMSEOccurrence()
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine#
+	 * getCurrentStep()
 	 */
 	@Override
-	public final MSEOccurrence getCurrentMSEOccurrence() {
+	public final Step<?> getCurrentStep() {
 		if (currentSteps.size() > 0)
-			return currentSteps.getFirst().getMseoccurrence();
+			return currentSteps.getFirst();
 		else
 			return null;
 	}
@@ -423,7 +417,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 		} catch (InterruptedException e) {
 			cleanCurrentTransactionCommand();
 			command.dispose();
-			SequentialExecutionException enclosingException = new SequentialExecutionException(getCurrentMSEOccurrence(), e);
+			SequentialExecutionException enclosingException = new SequentialExecutionException(getCurrentStep(), e);
 			enclosingException.initCause(e);
 			throw enclosingException;
 		}
@@ -454,8 +448,8 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	}
 
 	/**
-	 * To be called just after each execution step by an implementing engine. If
-	 * the step was done through a RecordingCommand, it can be given.
+	 * To be called just after each execution step by an implementing engine. If the
+	 * step was done through a RecordingCommand, it can be given.
 	 */
 	protected final void beforeExecutionStep(Step<?> step, RecordingCommand rc) {
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/SequentialExecutionException.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/SequentialExecutionException.xtend
@@ -11,6 +11,7 @@
  package org.eclipse.gemoc.executionframework.engine.core;
 
 import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence
+import org.eclipse.gemoc.trace.commons.model.trace.Step
 import org.eclipse.emf.transaction.RollbackException
 
 /**
@@ -20,25 +21,25 @@ import org.eclipse.emf.transaction.RollbackException
  */
 public class SequentialExecutionException extends RuntimeException {
 
-	private MSEOccurrence pendingMSEOccurrence;
+	private Step<?> pendingStep;
 
-	new(MSEOccurrence pendingMSE, Throwable cause) {
-		this.pendingMSEOccurrence = pendingMSE;
+	new(Step<?> pendingMSE, Throwable cause) {
+		this.pendingStep = pendingStep;
 		this.initCause(cause)
 	}
 
 	private def String prettyPrintMSEOcc() {
-		if (pendingMSEOccurrence !=	null)
-			return '''Pending MSEOccurrence: «pendingMSEOccurrence.mse.caller.eClass.name».«pendingMSEOccurrence.mse.action.name» called on «pendingMSEOccurrence.mse.caller».'''
+		if (pendingStep !==	null)
+			return '''Pending MSEOccurrence: «pendingStep.mseoccurrence.mse.caller.eClass.name».«pendingStep.mseoccurrence.mse.action.name» called on «pendingStep.mseoccurrence.mse.caller».'''
 		else
 			return "No pending MSE."
 	}
 
 	override getMessage() {
-		if (this.getCause() != null && this.getCause() instanceof RollbackException) {
+		if (this.getCause() !== null && this.getCause() instanceof RollbackException) {
 			return "An error occured during the execution of the operational semantics (originally catched as a RollbackException during the transaction commit).\n" +
 				prettyPrintMSEOcc;
-		} else if (this.getCause() != null && this.getCause() instanceof InterruptedException) {
+		} else if (this.getCause() !== null && this.getCause() instanceof InterruptedException) {
 			return "The engine thread was interrupted while it was waiting for being allowed to start an execution step's transaction.\n" +
 				prettyPrintMSEOcc;
 		} else {

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionEngine.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionEngine.java
@@ -13,11 +13,11 @@ package org.eclipse.gemoc.xdsmlframework.api.core;
 import java.util.Deque;
 import java.util.Set;
 
-import org.eclipse.gemoc.xdsmlframework.api.core.EngineStatus.RunStatus;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
-
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
 import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
+import org.eclipse.gemoc.xdsmlframework.api.core.EngineStatus.RunStatus;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 
 /**
  * The interface of the GEMOC Execution Engine. The Execution Engine is an
@@ -35,13 +35,13 @@ public interface IExecutionEngine extends IDisposable {
 	 * In case of nested calls, indicate the current stack of model specific event occurrences.
 	 * @return the current stack of {@link MSEOccurrence}
 	 */
-	Deque<MSEOccurrence> getCurrentStack();
+	Deque<Step<?>> getCurrentStack();
 
 	/**
 	 * Provides the model specific event occurrence of the current step 
 	 * @return the current MSEOccurrence
 	 */
-	MSEOccurrence getCurrentMSEOccurrence();
+	Step<?> getCurrentStep();
 
 	/**
 	 * Starts the {@link IExecutionEngine}.

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/debug/GenericSequentialModelDebugger.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/debug/GenericSequentialModelDebugger.java
@@ -55,8 +55,7 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	@Override
 	/*
-	 * This method is eventually called within a new engine thread.
-	 * (non-Javadoc)
+	 * This method is eventually called within a new engine thread. (non-Javadoc)
 	 * 
 	 * @see org.eclipse.gemoc.dsl.debug.ide.IDSLDebugger#start()
 	 */
@@ -71,16 +70,16 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	protected void setupStepReturnPredicateBreak() {
 		final IExecutionEngine seqEngine = (IExecutionEngine) engine;
-		final Deque<MSEOccurrence> stack = seqEngine.getCurrentStack();
+		final Deque<Step<?>> stack = seqEngine.getCurrentStack();
 		if (stack.size() > 1) {
-			final Iterator<MSEOccurrence> it = stack.iterator();
+			final Iterator<Step<?>> it = stack.iterator();
 			it.next();
-			addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
 				// The operation we want to step return
-				private MSEOccurrence steppedReturn = it.next();
+				private Step<?> steppedReturn = it.next();
 
 				@Override
-				public boolean test(IExecutionEngine t, MSEOccurrence u) {
+				public boolean test(IExecutionEngine t, Step<?> u) {
 					// We finished stepping over once the mseoccurrence is not
 					// there anymore
 					return !seqEngine.getCurrentStack().contains(steppedReturn);
@@ -98,13 +97,13 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 	}
 
 	protected void setupStepOverPredicateBreak() {
-		addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+		addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
 			final IExecutionEngine seqEngine = (IExecutionEngine) engine;
 			// The operation we want to step over
-			private MSEOccurrence steppedOver = seqEngine.getCurrentMSEOccurrence();
+			private Step<?> steppedOver = seqEngine.getCurrentStep();
 
 			@Override
-			public boolean test(IExecutionEngine t, MSEOccurrence u) {
+			public boolean test(IExecutionEngine t, Step<?> u) {
 				// We finished stepping over once the mseoccurrence is not there
 				// anymore
 				return !seqEngine.getCurrentStack().contains(steppedOver);
@@ -130,9 +129,9 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		// To send notifications, but probably useless
 		super.steppingInto(threadName);
 		// We add a future break asap
-		addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+		addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
 			@Override
-			public boolean test(IExecutionEngine t, MSEOccurrence u) {
+			public boolean test(IExecutionEngine t, Step<?> u) {
 				// We finished stepping as soon as we encounter a new step
 				return true;
 			}
@@ -158,11 +157,11 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		// Catching the stack up with events that occurred since last suspension
 		// We use a virtual stack to replay the last events to avoid pushing
 		// stackframes that would be popped right after.
-		Deque<MSEOccurrence> virtualStack = new ArrayDeque<>();
+		Deque<Step<?>> virtualStack = new ArrayDeque<>();
 		for (ToPushPop m : toPushPop) {
 			if (m.push) {
 				// We push the mse onto the virtual stack.
-				virtualStack.push(m.mseOccurrence);
+				virtualStack.push(m.step);
 			} else {
 				if (virtualStack.isEmpty()) {
 					// The virtual stack is empty, we pop the top stackframe off
@@ -177,17 +176,17 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		}
 
 		// We then push the missing stackframes onto the real stack.
-		Iterator<MSEOccurrence> iterator = virtualStack.descendingIterator();
+		Iterator<Step<?>> iterator = virtualStack.descendingIterator();
 		while (iterator.hasNext()) {
-			MSEOccurrence mseOccurrence = iterator.next();
-			EObject caller = mseOccurrence.getMse().getCaller();
+			Step<?> step = iterator.next();
+			EObject caller = step.getMseoccurrence().getMse().getCaller();
 			QualifiedName qname = nameprovider.getFullyQualifiedName(caller);
 			String objectName = "";
 			if (qname != null)
 				objectName = qname.toString();
 			else
 				objectName = caller.toString();
-			String opName = mseOccurrence.getMse().getAction().getName();
+			String opName = step.getMseoccurrence().getMse().getAction().getName();
 			String callerType = caller.eClass().getName();
 			String prettyName = "(" + callerType + ") " + objectName + " -> " + opName + "()";
 			pushStackFrame(threadName, prettyName, caller, caller);
@@ -218,8 +217,8 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	@Override
 	public boolean shouldBreak(EObject instruction) {
-		if (instruction instanceof MSEOccurrence) {
-			return shouldBreakMSEOccurence((MSEOccurrence) instruction);
+		if (instruction instanceof Step<?>) {
+			return shouldBreakStep((Step<?>) instruction);
 		} else if (instruction == FAKE_INSTRUCTION) {
 			// Part of the breakpoint simulation to suspend the execution once
 			// the end has been reached.
@@ -227,47 +226,48 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		}
 		return false;
 	}
-	
+
 	private boolean hasRegularBreakpointTrue(EObject o) {
 		EObject target = o;
-		// Try to get the original object if 'o' comes from 
+		// Try to get the original object if 'o' comes from
 		// a downcast resource
-		if(this.engine instanceof PlainK3ExecutionEngine){
+		if (this.engine instanceof PlainK3ExecutionEngine) {
 			Resource res = o.eResource();
-			if(res != null) {
-				
+			if (res != null) {
+
 				MelangeResourceImpl mr = null;
-				for(Resource candidate : res.getResourceSet().getResources()) {
-					if(candidate instanceof MelangeResourceImpl) {
+				for (Resource candidate : res.getResourceSet().getResources()) {
+					if (candidate instanceof MelangeResourceImpl) {
 						mr = (MelangeResourceImpl) candidate;
 						break;
 					}
 				}
-				
-				if(mr != null) {
+
+				if (mr != null) {
 					String uriFragment = res.getURIFragment(o);
 					target = mr.getWrappedResource().getEObject(uriFragment);
 				}
 			}
 		}
-		
-		return super.shouldBreak(target)
-				&& (Boolean.valueOf((String) getBreakpointAttributes(target, GemocBreakpoint.BREAK_ON_LOGICAL_STEP)) || Boolean
-						.valueOf((String) getBreakpointAttributes(target, GemocBreakpoint.BREAK_ON_MSE_OCCURRENCE)))
-//				&& checkBreakpointProperty(target, o)
-				;
+
+		return super.shouldBreak(target) && (Boolean
+				.valueOf((String) getBreakpointAttributes(target, GemocBreakpoint.BREAK_ON_LOGICAL_STEP))
+				|| Boolean.valueOf((String) getBreakpointAttributes(target, GemocBreakpoint.BREAK_ON_MSE_OCCURRENCE)))
+		// && checkBreakpointProperty(target, o)
+		;
+
 	}
 
-	private boolean shouldBreakMSEOccurence(MSEOccurrence mseOccurrence) {
-		if (shouldBreakPredicates(engine, mseOccurrence))
+	private boolean shouldBreakStep(Step<?> step) {
+		if (shouldBreakPredicates(engine, step))
 			return true;
 		// If still no break yet, we look at regular breakpoints on MSE
-		MSE mse = mseOccurrence.getMse();
+		MSE mse = step.getMseoccurrence().getMse();
 		if (hasRegularBreakpointTrue(mse)) {
 			return true;
 		}
 		// If still no break yet, we look at regular breakpoints on MSE's caller
-		EObject caller = mseOccurrence.getMse().getCaller();
+		EObject caller = mse.getCaller();
 		if (hasRegularBreakpointTrue(caller)) {
 			return true;
 		}
@@ -295,11 +295,11 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	@Override
 	public void aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> step) {
-		MSEOccurrence mseOccurrence = step.getMseoccurrence();
-		if (mseOccurrence != null) {
-			ToPushPop stackModification = new ToPushPop(mseOccurrence, true);
+		if (step.getMseoccurrence() != null && step.getMseoccurrence().getMse() != null) {
+			ToPushPop stackModification = new ToPushPop(step, true);
 			toPushPop.add(stackModification);
-			if (!control(threadName, mseOccurrence)) {
+			boolean shallcontinue = control(threadName, step);
+			if (!shallcontinue) {
 				throw new EngineStoppedException("Debug thread has stopped.");
 			}
 		}
@@ -307,9 +307,8 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	@Override
 	public void stepExecuted(IExecutionEngine engine, Step<?> step) {
-		MSEOccurrence mseOccurrence = step.getMseoccurrence();
-		if (mseOccurrence != null) {
-			ToPushPop stackModification = new ToPushPop(mseOccurrence, false);
+		if (step.getMseoccurrence() != null && step.getMseoccurrence().getMse() != null) {
+			ToPushPop stackModification = new ToPushPop(step, false);
 			toPushPop.add(stackModification);
 		}
 	}
@@ -331,11 +330,11 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 	}
 
 	private static class ToPushPop {
-		public MSEOccurrence mseOccurrence;
+		public Step<?> step;
 		public boolean push;
 
-		ToPushPop(MSEOccurrence mseOccurrence, boolean push) {
-			this.mseOccurrence = mseOccurrence;
+		ToPushPop(Step<?> step, boolean push) {
+			this.step = step;
 			this.push = push;
 		}
 	}

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/debug/OmniscientGenericSequentialModelDebugger.xtend
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/debug/OmniscientGenericSequentialModelDebugger.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
@@ -12,7 +12,6 @@ package org.eclipse.gemoc.execution.sequential.javaengine.ui.debug;
 
 import org.eclipse.gemoc.trace.commons.model.trace.Dimension
 import org.eclipse.gemoc.trace.commons.model.trace.MSE
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence
 import org.eclipse.gemoc.trace.commons.model.trace.State
 import org.eclipse.gemoc.trace.commons.model.trace.Step
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject
@@ -35,7 +34,7 @@ import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
 
 public class OmniscientGenericSequentialModelDebugger extends GenericSequentialModelDebugger implements ITraceViewListener {
 
-	private var ITraceExplorer<Step<?>, State<?,?>, TracedObject<?>, Dimension<?>, Value<?>> traceExplorer
+	private var ITraceExplorer<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExplorer
 
 	private var steppingOverStackFrameIndex = -1
 
@@ -44,7 +43,7 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 	private val List<EObject> callerStack = new ArrayList
 
 	private val List<Step<?>> previousCallStack = new ArrayList
-	
+
 	new(IDSLDebugEventProcessor target, IExecutionEngine engine) {
 		super(target, engine)
 	}
@@ -57,7 +56,8 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 				val parentStep = container as Step<?>
 				val parentMseOccurrence = parentStep.mseoccurrence
 				if (parentMseOccurrence == null) {
-					throw new IllegalStateException("A step without MSEOccurrence cannot be contained in a step without MSEOccurrence")
+					throw new IllegalStateException(
+						"A step without MSEOccurrence cannot be contained in a step without MSEOccurrence")
 				} else {
 					return parentMseOccurrence.mse
 				}
@@ -74,7 +74,11 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 		var EObject caller = mse.caller
 		val QualifiedName qname = nameprovider.getFullyQualifiedName(caller)
 		val String objectName = if(qname !== null) qname.toString() else caller.toString()
-		val String opName = if (step.mseoccurrence == null) {mse.action?.name + "_implicitStep"} else {mse.action?.name}
+		val String opName = if (step.mseoccurrence == null) {
+				mse.action?.name + "_implicitStep"
+			} else {
+				mse.action?.name
+			}
 		val String callerType = caller.eClass().getName()
 		val String prettyName = "(" + callerType + ") " + objectName + " -> " + opName + "()"
 		pushStackFrame(threadName, prettyName, caller, caller)
@@ -85,11 +89,12 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 		super.popStackFrame(threadName)
 		callerStack.remove(0)
 	}
-	
+
 	override void aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> step) {
 		val mseOccurrence = step.mseoccurrence
-		if (mseOccurrence != null) {
-			if (!control(threadName, mseOccurrence)) {
+		if (mseOccurrence !== null) {
+			val boolean shallContinue = control(threadName, step)
+			if (! shallContinue) {
 				throw new EngineStoppedException("Debug thread has stopped.");
 			}
 		}
@@ -124,11 +129,11 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 			val stack = traceExplorer.callStack
 			val idx = stack.size - steppingOverStackFrameIndex - 1
 			// We add a future break as soon as the step is over
-			addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
 				// The operation we want to step over
-				private MSEOccurrence steppedOver = stack.get(idx).mseoccurrence
+				private Step<?> steppedOver = stack.get(idx)
 
-				override test(IExecutionEngine t, MSEOccurrence u) {
+				override test(IExecutionEngine t, Step<?> u) {
 					return !seqEngine.getCurrentStack().contains(steppedOver)
 				}
 			})
@@ -166,10 +171,10 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 			val seqEngine = engine as IExecutionEngine
 			val stack = traceExplorer.callStack
 			val idx = stack.size - steppingReturnStackFrameIndex - 1
-			addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
-				private MSEOccurrence steppedReturn = stack.get(idx).mseoccurrence
+			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
+				private Step<?> steppedReturn = stack.get(idx)
 
-				override test(IExecutionEngine t, MSEOccurrence u) {
+				override test(IExecutionEngine t, Step<?> u) {
 					return !seqEngine.getCurrentStack().contains(steppedReturn)
 				}
 			})
@@ -224,7 +229,6 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 //			}
 //		});
 //	}
-
 	override public validateVariableValue(String threadName, String variableName, String value) {
 		if (traceExplorer.inReplayMode) {
 			ErrorDialog.openError(null, "Illegal variable value set",
@@ -258,7 +262,8 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 
 	override updateStack(String threadName, EObject instruction) {
 		var i = 0
-		while (i < previousCallStack.size && i < traceExplorer.callStack.size && previousCallStack.get(i) == traceExplorer.callStack.get(i)) {
+		while (i < previousCallStack.size && i < traceExplorer.callStack.size &&
+			previousCallStack.get(i) == traceExplorer.callStack.get(i)) {
 			i++
 		}
 		for (var j = i; j < previousCallStack.size; j++) {
@@ -277,10 +282,9 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 	override update() {
 		if (executedModelRoot != null) {
 			try {
-				if(!callerStack.empty){
+				if (!callerStack.empty) {
 					updateData(threadName, callerStack.findFirst[true])
 				} else {
-					
 				}
 			} catch (IllegalStateException e) {
 				// Shhh

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
@@ -46,6 +46,7 @@ import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfigura
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfigurationParameter;
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchconfigurationPackage;
 import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.trace.gemoc.api.IMultiDimensionalTraceAddon;
 import org.eclipse.gemoc.dsl.debug.ide.IDSLDebugger;
 import org.eclipse.gemoc.dsl.debug.ide.event.DSLDebugEventDispatcher;
@@ -99,9 +100,9 @@ public class Launcher extends AbstractSequentialGemocLauncher {
 		// we add this dummy break
 		try {
 			if (configuration.getAttribute(RunConfiguration.LAUNCH_BREAK_START, false)) {
-				res.addPredicateBreak(new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+				res.addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
 					@Override
-					public boolean test(IExecutionEngine t, MSEOccurrence u) {
+					public boolean test(IExecutionEngine t, Step<?> u) {
 						return true;
 					}
 				});

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/src/org/eclipse/gemoc/addon/multidimensional/timeline/views/MultidimensionalTimelineViewPart.java
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/src/org/eclipse/gemoc/addon/multidimensional/timeline/views/MultidimensionalTimelineViewPart.java
@@ -66,7 +66,6 @@ import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 
 import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
 import org.eclipse.gemoc.trace.commons.model.trace.Dimension;
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;
@@ -433,10 +432,10 @@ public class MultidimensionalTimelineViewPart extends EngineSelectionDependentVi
 					if (!debuggers.isEmpty()) {
 						debugger = debuggers.stream().findFirst().get();
 						if (breakAtVectorState != null) {
-							BiPredicate<IExecutionEngine, MSEOccurrence> predicate = new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+							BiPredicate<IExecutionEngine, Step<?>> predicate = new BiPredicate<IExecutionEngine, Step<?>>() {
 								final State<?,?> baseState = breakAtVectorState;
 								@Override
-								public boolean test(IExecutionEngine executionEngine, MSEOccurrence mseOccurrence) {
+								public boolean test(IExecutionEngine executionEngine, Step<?> step) {
 									final ITraceExtractor<Step<?>, State<?,?>, TracedObject<?>, Dimension<?>, Value<?>> traceExtractor = traceAddon.getTraceExtractor();
 									final int lastStateIndex = traceExtractor.getStatesTraceLength() - 1;
 									final State<?,?> state = traceExtractor.getState(lastStateIndex);
@@ -447,10 +446,10 @@ public class MultidimensionalTimelineViewPart extends EngineSelectionDependentVi
 							breakAtVectorState = null;
 						}
 						if (breakAtStateIndex != -1) {
-							BiPredicate<IExecutionEngine, MSEOccurrence> predicate = new BiPredicate<IExecutionEngine, MSEOccurrence>() {
+							BiPredicate<IExecutionEngine, Step<?>> predicate = new BiPredicate<IExecutionEngine, Step<?>>() {
 								final int stateToBreakTo = breakAtStateIndex;
 								@Override
-								public boolean test(IExecutionEngine executionEngine, MSEOccurrence mseOccurrence) {
+								public boolean test(IExecutionEngine executionEngine, Step<?> step) {
 									final int traceLength = extractor.getStatesTraceLength();
 									final int stateToBreakTo = this.stateToBreakTo;
 									final boolean result = traceLength == stateToBreakTo + 1;


### PR DESCRIPTION
A significant amount of legacy code still relied on MSEOccurrence instances instead of Step instances to manage the current state of the Engine or of the Debugger. Since Steps contain more information, this PR make changes in the API and in implementations to make this switch.

This PR will facilitate the management of https://github.com/eclipse/gemoc-studio-modeldebugging/issues/32 , as we will be able to more easily know what kind of step we are dealing with at the top of the debugger stack.

Signed-off-by: Erwan Bousse erwan.bousse@tuwien.ac.at
