### PR TITLE
[Trace Generator] Avoid direct access to the model

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/DefaultDynamicPartAccessor.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/DefaultDynamicPartAccessor.java
@@ -1,0 +1,105 @@
+package org.eclipse.gemoc.executionframework.debugger;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.gemoc.xdsmlframework.commons.DynamicAnnotationHelper;
+import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider;
+import org.eclipse.xtext.naming.QualifiedName;
+
+public class DefaultDynamicPartAccessor implements IDynamicPartAccessor {
+	
+	Map<EClass, Integer> counters = new HashMap<>();
+
+	@Override
+	public List<MutableField> extractMutableField(EObject eObject) {
+		
+		List<MutableField> result = new ArrayList<MutableField>();
+		if(eObject == null) {
+			return result;
+		}
+
+		final List<EStructuralFeature> mutableProperties = 
+			eObject
+			.eClass()
+			.getEAllStructuralFeatures()
+			.stream()
+			.filter(p -> DynamicAnnotationHelper.isDynamic(p))
+			.collect(Collectors.toList());
+		
+		for(EStructuralFeature feature : mutableProperties) {
+			
+			Supplier<Object> getter = () -> {
+				return eObject.eGet(feature);
+			};
+			
+			Consumer<Object> setter = newValue -> {
+				eObject.eSet(feature, newValue);
+			};
+			
+			MutableField field = new MutableField(
+				feature.getName()+" ("+getName(eObject)+ " :"+eObject.eClass().getName() +")",
+				eObject,
+				feature,
+				getter,
+				setter
+				);
+			result.add(field);
+		}
+		
+		return result;
+	}
+	
+	private String getName(EObject eObject) {
+		DefaultDeclarativeQualifiedNameProvider nameprovider = new DefaultDeclarativeQualifiedNameProvider();
+		
+		EAttribute idProp = eObject.eClass().getEIDAttribute();
+		if (idProp != null) {
+			Object id = eObject.eGet(idProp);
+			if (id != null) {
+				NumberFormat formatter = new DecimalFormat("00");
+				String idString = id.toString();
+				if(id instanceof Integer){
+					idString = formatter.format((Integer)id);
+				}
+				return eObject.eClass().getName() + "_" + idString;
+			} else {
+				if (!counters.containsKey(eObject.eClass())) {
+					counters.put(eObject.eClass(), 0);
+				}
+				Integer counter = counters.get(eObject.eClass());
+				counters.put(eObject.eClass(), counter + 1);
+				return eObject.eClass().getName() + "_" + counter;
+			}
+
+		} else {
+			QualifiedName qname = nameprovider.getFullyQualifiedName(eObject);
+			if(qname == null) 
+				return eObject.toString();
+			else 
+				return qname.toString();
+		}
+	}
+
+	@Override
+	public boolean isDynamic(EObject obj) {
+		
+		if(obj == null) {
+			return false;
+		}
+		
+		return DynamicAnnotationHelper.isDynamic(obj.eClass());
+	}
+
+}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IDynamicPartAccessor.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IDynamicPartAccessor.java
@@ -1,0 +1,12 @@
+package org.eclipse.gemoc.executionframework.debugger;
+
+import org.eclipse.emf.ecore.EObject;
+
+public interface IDynamicPartAccessor extends IMutableFieldExtractor {
+
+	/**
+	 * Return true if the class of {@link obj} is defined in the semantics
+	 */
+	public boolean isDynamic(EObject obj);
+	
+}

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
@@ -17,4 +17,5 @@ Require-Bundle: org.eclipse.gemoc.timeline;bundle-version="1.0.0",
  org.eclipse.gemoc.xdsmlframework.commons
 Export-Package: org.eclipse.gemoc.trace.gemoc.traceaddon
 Bundle-ActivationPolicy: lazy
+Import-Package: org.eclipse.gemoc.executionframework.debugger
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
@@ -82,28 +82,24 @@ public class GenericStateManager implements IStateManager<State<?, ?>> {
 			if (originalObject == null) {
 				originalObject = tracedToExe.get(tracedObject);
 			}
-			if (v instanceof GenericAttributeValue) {
-				if (v instanceof IntegerAttributeValue) {
-					if(dynamicProperty.isPresent())
+			
+			if(dynamicProperty.isPresent()) {
+				if (v instanceof GenericAttributeValue) {
+					if (v instanceof IntegerAttributeValue) {
 						dynamicProperty.get().setValue(((IntegerAttributeValue) v).getAttributeValue());
-				} else if (v instanceof BooleanAttributeValue) {
-					if(dynamicProperty.isPresent())
+					} else if (v instanceof BooleanAttributeValue) {
 						dynamicProperty.get().setValue(((BooleanAttributeValue) v).isAttributeValue());
-				} else {
-					if(dynamicProperty.isPresent())
-						dynamicProperty.get().setValue(((StringAttributeValue) v).getAttributeValue());
-				}
-			} else {
-				if (v instanceof SingleReferenceValue) {
-					final EObject refVal = ((SingleReferenceValue) v).getReferenceValue();
-					if (refVal instanceof GenericTracedObject) {
-						final EObject exe = tracedToExe.get(refVal);
-						if(dynamicProperty.isPresent())
-							dynamicProperty.get().setValue(exe);
 					} else {
-						if(dynamicProperty.isPresent())
-							dynamicProperty.get().setValue(refVal);
+						dynamicProperty.get().setValue(((StringAttributeValue) v).getAttributeValue());
 					}
+				} else if (v instanceof SingleReferenceValue) {
+						final EObject refVal = ((SingleReferenceValue) v).getReferenceValue();
+						if (refVal instanceof GenericTracedObject) {
+							final EObject exe = tracedToExe.get(refVal);
+							dynamicProperty.get().setValue(exe);
+						} else {
+							dynamicProperty.get().setValue(refVal);
+						}
 				} else {
 					final List<EObject> values = new BasicEList<EObject>();
 					values.addAll(((ManyReferenceValue) v).getReferenceValues().stream().map(refVal -> {
@@ -113,8 +109,7 @@ public class GenericStateManager implements IStateManager<State<?, ?>> {
 							return refVal;
 						}
 					}).collect(Collectors.toList()));
-					if(dynamicProperty.isPresent())
-						dynamicProperty.get().setValue(values);
+					dynamicProperty.get().setValue(values);
 				}
 			}
 		});

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
+import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.MutableField;
 import org.eclipse.gemoc.executionframework.engine.core.CommandExecution;
@@ -44,12 +45,12 @@ public class GenericStateManager implements IStateManager<State<?, ?>> {
 	
 	private final Map<TracedObject<?>, EObject> tracedToExe;
 	
-	IMutableFieldExtractor fieldExtractor;
+	IDynamicPartAccessor dynamicPartAccessor;
 	
-	public GenericStateManager(Resource modelResource, Map<TracedObject<?>, EObject> tracedToExe, IMutableFieldExtractor fieldExtractor) {
+	public GenericStateManager(Resource modelResource, Map<TracedObject<?>, EObject> tracedToExe, IDynamicPartAccessor dynamicPartAccessor) {
 		this.modelResource = modelResource;
 		this.tracedToExe = tracedToExe;
-		this.fieldExtractor = fieldExtractor;
+		this.dynamicPartAccessor = dynamicPartAccessor;
 	}
 	
 	@Override
@@ -77,7 +78,7 @@ public class GenericStateManager implements IStateManager<State<?, ?>> {
 			GenericDimension dimension = (GenericDimension) v.eContainer();
 			GenericTracedObject tracedObject = (GenericTracedObject) dimension.eContainer();
 			EObject originalObject = tracedObject.getOriginalObject();
-			List<MutableField> fields = fieldExtractor.extractMutableField(originalObject);
+			List<MutableField> fields = dynamicPartAccessor.extractMutableField(originalObject);
 			Optional<MutableField> dynamicProperty = fields.stream().filter(field -> field.getMutableProperty().getName().equals(dimension.getDynamicProperty().getName())).findFirst();
 			if (originalObject == null) {
 				originalObject = tracedToExe.get(tracedObject);

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
-
+import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
 import org.eclipse.gemoc.trace.commons.model.trace.Trace;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;
@@ -25,6 +25,7 @@ import org.eclipse.gemoc.trace.gemoc.api.ITraceConstructor;
 public class GenericTraceEngineAddon extends AbstractTraceAddon {
 
 	private GenericTraceStepFactory factory = null;
+	IMutableFieldExtractor fieldExtractor;
 	
 	@Override
 	public IStepFactory getFactory() {
@@ -37,7 +38,7 @@ public class GenericTraceEngineAddon extends AbstractTraceAddon {
 	@Override
 	public ITraceConstructor constructTraceConstructor(Resource modelResource,
 			Resource traceResource, Map<EObject, TracedObject<?>> exeToTraced) {
-		return new GenericTraceConstructor(modelResource, traceResource, exeToTraced);
+		return new GenericTraceConstructor(modelResource, traceResource, exeToTraced, fieldExtractor);
 	}
 
 	@Override
@@ -47,7 +48,11 @@ public class GenericTraceEngineAddon extends AbstractTraceAddon {
 
 	@Override
 	public IStateManager<State<?, ?>> constructStateManager(Resource modelResource, Map<TracedObject<?>, EObject> tracedToExe) {
-		return new GenericStateManager(modelResource, tracedToExe);
+		return new GenericStateManager(modelResource, tracedToExe, fieldExtractor);
+	}
+	
+	public void setIMutableFieldExtractor(IMutableFieldExtractor fieldExtractor) {
+		this.fieldExtractor = fieldExtractor;
 	}
 
 }

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
 import org.eclipse.gemoc.trace.commons.model.trace.Trace;
@@ -25,7 +26,7 @@ import org.eclipse.gemoc.trace.gemoc.api.ITraceConstructor;
 public class GenericTraceEngineAddon extends AbstractTraceAddon {
 
 	private GenericTraceStepFactory factory = null;
-	IMutableFieldExtractor fieldExtractor;
+	IDynamicPartAccessor dynamicPartAccessor;
 	
 	@Override
 	public IStepFactory getFactory() {
@@ -38,7 +39,7 @@ public class GenericTraceEngineAddon extends AbstractTraceAddon {
 	@Override
 	public ITraceConstructor constructTraceConstructor(Resource modelResource,
 			Resource traceResource, Map<EObject, TracedObject<?>> exeToTraced) {
-		return new GenericTraceConstructor(modelResource, traceResource, exeToTraced, fieldExtractor);
+		return new GenericTraceConstructor(modelResource, traceResource, exeToTraced, dynamicPartAccessor);
 	}
 
 	@Override
@@ -48,11 +49,11 @@ public class GenericTraceEngineAddon extends AbstractTraceAddon {
 
 	@Override
 	public IStateManager<State<?, ?>> constructStateManager(Resource modelResource, Map<TracedObject<?>, EObject> tracedToExe) {
-		return new GenericStateManager(modelResource, tracedToExe, fieldExtractor);
+		return new GenericStateManager(modelResource, tracedToExe, dynamicPartAccessor);
 	}
 	
-	public void setIMutableFieldExtractor(IMutableFieldExtractor fieldExtractor) {
-		this.fieldExtractor = fieldExtractor;
+	public void setDynamicPartAccessor(IDynamicPartAccessor dynamicPartAccessor) {
+		this.dynamicPartAccessor = dynamicPartAccessor;
 	}
 
 }

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.gemoc.executionframework.debugger.DefaultDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
@@ -26,7 +27,7 @@ import org.eclipse.gemoc.trace.gemoc.api.ITraceConstructor;
 public class GenericTraceEngineAddon extends AbstractTraceAddon {
 
 	private GenericTraceStepFactory factory = null;
-	IDynamicPartAccessor dynamicPartAccessor;
+	IDynamicPartAccessor dynamicPartAccessor = new DefaultDynamicPartAccessor();
 	
 	@Override
 	public IStepFactory getFactory() {


### PR DESCRIPTION
I am currently implementing a Gemoc engine for ALE and I have some trouble with the TraceGenerator code.
It basically looks at EStructuralFeatures tagged @aspect for each object of the model to construct the trace.

My problem is that models for the ALE Interpreter are Sets of <Object, DynamicPart> (both are EObject, one for the original object, the second to store dynamics properties déclared in .ale files)
Since Gemoc assume both parts are merged, the TraceGenerator doesn't work here.

The idea is to replace direct usage of eGet() and eSet() by MutableField's methods.
It allows to provides engine-specific accessors to know where to look for dynamic data.
https://github.com/eclipse/gemoc-studio-modeldebugging/blob/master/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/MutableField.java