### PR TITLE
Execution framework refactoring

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
@@ -29,6 +29,7 @@ Require-Bundle: com.google.guava,
  fr.inria.diverse.melange.resource,
  org.eclipse.gemoc.dsl.debug.ide.ui;bundle-version="2.4.0",
  org.eclipse.sirius;bundle-version="4.1.3",
- org.eclipse.debug.ui
+ org.eclipse.debug.ui,
+ org.eclipse.emf.transaction;bundle-version="1.9.0"
 Bundle-ActivationPolicy: lazy
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/src/org/eclipse/gemoc/executionframework/debugger/ui/OpenSemanticsHandler.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/src/org/eclipse/gemoc/executionframework/debugger/ui/OpenSemanticsHandler.java
@@ -36,7 +36,7 @@ import org.eclipse.gemoc.dsl.debug.ide.adapter.DSLThreadAdapter;
 
 public class OpenSemanticsHandler extends AbstractHandler {
 
-	private IExecutionEngine engine;
+	private IExecutionEngine<?> engine;
 
 	private String bundleSymbolicName;
 
@@ -67,7 +67,7 @@ public class OpenSemanticsHandler extends AbstractHandler {
 			}
 		}
 
-		Thread thread = ((AbstractExecutionEngine) engine).thread;
+		Thread thread = ((AbstractExecutionEngine<?, ?>) engine).thread;
 		StackTraceElement[] stackTrace = thread.getStackTrace();
 		String className = engine.getClass().getName();
 		String methodName = "executeStep";
@@ -102,7 +102,7 @@ public class OpenSemanticsHandler extends AbstractHandler {
 	}
 
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		Supplier<IExecutionEngine> engineSupplier = org.eclipse.gemoc.executionframework.debugger.Activator.getDefault().getEngineSupplier();
+		Supplier<IExecutionEngine<?>> engineSupplier = org.eclipse.gemoc.executionframework.debugger.Activator.getDefault().getEngineSupplier();
 		Supplier<String> bundleSupplier = org.eclipse.gemoc.executionframework.debugger.Activator.getDefault().getBundleSymbolicNameSupplier();
 		if (engineSupplier != null) {
 			this.engine = engineSupplier.get();
@@ -120,7 +120,7 @@ public class OpenSemanticsHandler extends AbstractHandler {
 		this.bundleSymbolicName = bundleSymbolicName;
 	}
 
-	public void setEngine(IExecutionEngine engine) {
+	public void setEngine(IExecutionEngine<?> engine) {
 		this.engine = engine;
 	}
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebugger.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebugger.java
@@ -38,7 +38,6 @@ import org.eclipse.gemoc.dsl.debug.StackFrame;
 import org.eclipse.gemoc.dsl.debug.ide.AbstractDSLDebugger;
 import org.eclipse.gemoc.dsl.debug.ide.adapter.DSLStackFrameAdapter;
 import org.eclipse.gemoc.dsl.debug.ide.event.IDSLDebugEventProcessor;
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.FieldChange;
@@ -78,13 +77,13 @@ public abstract class AbstractGemocDebugger extends AbstractDSLDebugger implemen
 
 	protected EObject executedModelRoot = null;
 
-	protected final IExecutionEngine engine;
+	protected final IExecutionEngine<?> engine;
 
 	private String bundleSymbolicName;
 
 	private List<IMutableFieldExtractor> mutableFieldExtractors = new ArrayList<>();
 
-	public AbstractGemocDebugger(IDSLDebugEventProcessor target, IExecutionEngine engine) {
+	public AbstractGemocDebugger(IDSLDebugEventProcessor target, IExecutionEngine<?> engine) {
 		super(target);
 		this.engine = engine;
 
@@ -116,15 +115,15 @@ public abstract class AbstractGemocDebugger extends AbstractDSLDebugger implemen
 		this.mutableFieldExtractors = mutableFieldExtractors;
 	}
 
-	private Set<BiPredicate<IExecutionEngine, Step<?>>> predicateBreakPoints = new HashSet<BiPredicate<IExecutionEngine, Step<?>>>();
-	private Set<BiPredicate<IExecutionEngine, Step<?>>> predicateBreaks = new HashSet<BiPredicate<IExecutionEngine, Step<?>>>();
+	private Set<BiPredicate<IExecutionEngine<?>, Step<?>>> predicateBreakPoints = new HashSet<BiPredicate<IExecutionEngine<?>, Step<?>>>();
+	private Set<BiPredicate<IExecutionEngine<?>, Step<?>>> predicateBreaks = new HashSet<BiPredicate<IExecutionEngine<?>, Step<?>>>();
 
 	@Override
 	/**
 	 * Breakpoints are persistent, and can trigger pauses as long as they are not
 	 * removed.
 	 */
-	public void addPredicateBreakpoint(BiPredicate<IExecutionEngine, Step<?>> predicate) {
+	public void addPredicateBreakpoint(BiPredicate<IExecutionEngine<?>, Step<?>> predicate) {
 		predicateBreakPoints.add(predicate);
 	}
 
@@ -132,16 +131,16 @@ public abstract class AbstractGemocDebugger extends AbstractDSLDebugger implemen
 	/**
 	 * A Break only trigger a single pause, then is removed.
 	 */
-	public void addPredicateBreak(BiPredicate<IExecutionEngine, Step<?>> predicate) {
+	public void addPredicateBreak(BiPredicate<IExecutionEngine<?>, Step<?>> predicate) {
 		predicateBreaks.add(predicate);
 	}
 
-	protected boolean shouldBreakPredicates(IExecutionEngine engine, Step<?> step) {
+	protected boolean shouldBreakPredicates(IExecutionEngine<?> engine, Step<?> step) {
 
 		// We look at predicate breaks to remove the ones that are true
 		boolean shouldBreak = false;
-		Set<BiPredicate<IExecutionEngine, Step<?>>> toRemove = new HashSet<BiPredicate<IExecutionEngine, Step<?>>>();
-		for (BiPredicate<IExecutionEngine, Step<?>> pred : predicateBreaks) {
+		Set<BiPredicate<IExecutionEngine<?>, Step<?>>> toRemove = new HashSet<BiPredicate<IExecutionEngine<?>, Step<?>>>();
+		for (BiPredicate<IExecutionEngine<?>, Step<?>> pred : predicateBreaks) {
 			if (pred.test(engine, step)) {
 				shouldBreak = true;
 				toRemove.add(pred);
@@ -152,7 +151,7 @@ public abstract class AbstractGemocDebugger extends AbstractDSLDebugger implemen
 			return true;
 
 		// If no break yet, we look at predicate breakpoints
-		for (BiPredicate<IExecutionEngine, Step<?>> pred : predicateBreakPoints) {
+		for (BiPredicate<IExecutionEngine<?>, Step<?>> pred : predicateBreakPoints) {
 			if (pred.test(engine, step)) {
 				return true;
 			}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebuggerFactory.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebuggerFactory.java
@@ -16,9 +16,9 @@ import org.eclipse.gemoc.dsl.debug.ide.event.IDSLDebugEventProcessor;
 
 public abstract class AbstractGemocDebuggerFactory {
 
-	public AbstractGemocDebuggerFactory(){
-		
+	public AbstractGemocDebuggerFactory() {
+
 	}
-	
-	public abstract AbstractGemocDebugger createDebugger(IDSLDebugEventProcessor target, IExecutionEngine engine); 
+
+	public abstract AbstractGemocDebugger createDebugger(IDSLDebugEventProcessor target, IExecutionEngine<?> engine);
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/Activator.java
@@ -31,13 +31,13 @@ public class Activator extends GemocPlugin {
 	// The shared instance
 	private static Activator plugin;
 
-	private Supplier<IExecutionEngine> engineSupplier;
+	private Supplier<IExecutionEngine<?>> engineSupplier;
 
 	private Supplier<String> bundleSymbolicNameSupplier;
 
 	private Supplier<OmniscientGenericSequentialModelDebugger> debuggerSupplier;
 
-	public void setHandlerFieldSuppliers(Supplier<IExecutionEngine> engineSupplier,
+	public void setHandlerFieldSuppliers(Supplier<IExecutionEngine<?>> engineSupplier,
 			Supplier<String> bundleSymbolicNameSupplier) {
 		this.engineSupplier = engineSupplier;
 		this.bundleSymbolicNameSupplier = bundleSymbolicNameSupplier;
@@ -100,7 +100,7 @@ public class Activator extends GemocPlugin {
 		return _loggingBackend;
 	}
 
-	public Supplier<IExecutionEngine> getEngineSupplier() {
+	public Supplier<IExecutionEngine<?>> getEngineSupplier() {
 		return engineSupplier;
 	}
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/GenericSequentialModelDebugger.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/GenericSequentialModelDebugger.xtend
@@ -47,7 +47,7 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 
 	protected boolean executionTerminated = false;
 
-	new(IDSLDebugEventProcessor target, IExecutionEngine engine) {
+	new(IDSLDebugEventProcessor target, IExecutionEngine<?> engine) {
 		super(target, engine);
 	}
 
@@ -65,16 +65,16 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 	}
 
 	protected def void setupStepReturnPredicateBreak() {
-		val IExecutionEngine seqEngine = engine as IExecutionEngine;
+		val IExecutionEngine<?> seqEngine = engine as IExecutionEngine<?>;
 		val Deque<Step<?>> stack = seqEngine.getCurrentStack();
 		if (stack.size() > 1) {
 			val Iterator<Step<?>> it = stack.iterator();
 			it.next();
-			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
+			addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
 				// The operation we want to step return
 				private Step<?> steppedReturn = it.next();
 
-				override test(IExecutionEngine t, Step<?> u) {
+				override test(IExecutionEngine<?> t, Step<?> u) {
 					// We finished stepping over once the step is not
 					// there anymore
 					return !seqEngine.getCurrentStack().contains(steppedReturn);
@@ -91,12 +91,12 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 	}
 
 	def protected setupStepOverPredicateBreak() {
-		addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
-			val IExecutionEngine seqEngine = engine as IExecutionEngine;
+		addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
+			val IExecutionEngine<?> seqEngine = engine as IExecutionEngine<?>;
 			// The operation we want to step over
 			private Step<?> steppedOver = seqEngine.getCurrentStep();
 
-			override test(IExecutionEngine t, Step<?> u) {
+			override test(IExecutionEngine<?> t, Step<?> u) {
 				// We finished stepping over once the step is not there
 				// anymore
 				return !seqEngine.getCurrentStack().contains(steppedOver);
@@ -123,8 +123,8 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		// To send notifications, but probably useless
 		super.steppingInto(threadName);
 		// We add a future break asap
-		addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
-			override test(IExecutionEngine t, Step<?> u) {
+		addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
+			override test(IExecutionEngine<?> t, Step<?> u) {
 				// We finished stepping as soon as we encounter a new step
 				return true;
 			}
@@ -310,17 +310,17 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		return FAKE_INSTRUCTION;
 	}
 
-	override engineStarted(IExecutionEngine executionEngine) {
+	override engineStarted(IExecutionEngine<?> executionEngine) {
 		spawnRunningThread(threadName, engine.getExecutionContext().getResourceModel().getContents().get(0));
 	}
 
-	override engineStopped(IExecutionEngine engine) {
+	override engineStopped(IExecutionEngine<?> engine) {
 		if (!isTerminated(threadName)) {
 			terminated(threadName);
 		}
 	}
 
-	override aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> step) {
+	override aboutToExecuteStep(IExecutionEngine<?> executionEngine, Step<?> step) {
 		val ToPushPop stackModification = new ToPushPop(step, true);
 		toPushPop.add(stackModification);
 		val boolean shallcontinue = control(threadName, step);
@@ -329,12 +329,12 @@ public class GenericSequentialModelDebugger extends AbstractGemocDebugger {
 		}
 	}
 
-	override stepExecuted(IExecutionEngine engine, Step<?> step) {
+	override stepExecuted(IExecutionEngine<?> engine, Step<?> step) {
 		val ToPushPop stackModification = new ToPushPop(step, false);
 		toPushPop.add(stackModification);
 	}
 
-	override engineAboutToStop(IExecutionEngine engine) {
+	override engineAboutToStop(IExecutionEngine<?> engine) {
 		// Simulating breakpoint
 		// TODO maybe display a warning informing the user the execution has
 		// ended, as resuming execution will prevent further interactions with the

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IGemocDebugger.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/IGemocDebugger.java
@@ -12,16 +12,14 @@ package org.eclipse.gemoc.executionframework.debugger;
 
 import java.util.function.BiPredicate;
 
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
-import org.eclipse.gemoc.trace.commons.model.trace.Step;
-
 public interface IGemocDebugger extends IEngineAddon {
 
-	public abstract void addPredicateBreak(BiPredicate<IExecutionEngine, Step<?>> predicate);
+	public abstract void addPredicateBreak(BiPredicate<IExecutionEngine<?>, Step<?>> predicate);
 
-	public abstract void addPredicateBreakpoint(BiPredicate<IExecutionEngine, Step<?>> predicate);
+	public abstract void addPredicateBreakpoint(BiPredicate<IExecutionEngine<?>, Step<?>> predicate);
 
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/OmniscientGenericSequentialModelDebugger.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/OmniscientGenericSequentialModelDebugger.xtend
@@ -41,7 +41,7 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 
 	private val List<Step<?>> previousCallStack = new ArrayList
 
-	new(IDSLDebugEventProcessor target, IExecutionEngine engine) {
+	new(IDSLDebugEventProcessor target, IExecutionEngine<?> engine) {
 		super(target, engine)
 	}
 
@@ -56,7 +56,7 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 		callerStack.remove(0)
 	}
 
-	override void aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> step) {
+	override void aboutToExecuteStep(IExecutionEngine<?> executionEngine, Step<?> step) {
 		val mseOccurrence = step.mseoccurrence
 		if (mseOccurrence !== null) {
 			val boolean shallContinue = control(threadName, step)
@@ -91,15 +91,15 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 
 	override protected void setupStepOverPredicateBreak() {
 		if (steppingOverStackFrameIndex != -1) {
-			val seqEngine = engine as IExecutionEngine
+			val seqEngine = engine as IExecutionEngine<?>
 			val stack = traceExplorer.callStack
 			val idx = stack.size - steppingOverStackFrameIndex - 1
 			// We add a future break as soon as the step is over
-			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
+			addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
 				// The operation we want to step over
 				private Step<?> steppedOver = stack.get(idx)
 
-				override test(IExecutionEngine t, Step<?> u) {
+				override test(IExecutionEngine<?> t, Step<?> u) {
 					return !seqEngine.getCurrentStack().contains(steppedOver)
 				}
 			})
@@ -134,13 +134,13 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 
 	override protected void setupStepReturnPredicateBreak() {
 		if (steppingReturnStackFrameIndex != -1) {
-			val seqEngine = engine as IExecutionEngine
+			val seqEngine = engine as IExecutionEngine<?>
 			val stack = traceExplorer.callStack
 			val idx = stack.size - steppingReturnStackFrameIndex - 1
-			addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
+			addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
 				private Step<?> steppedReturn = stack.get(idx)
 
-				override test(IExecutionEngine t, Step<?> u) {
+				override test(IExecutionEngine<?> t, Step<?> u) {
 					return !seqEngine.getCurrentStack().contains(steppedReturn)
 				}
 			})
@@ -205,7 +205,7 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 		return super.validateVariableValue(threadName, variableName, value)
 	}
 
-	override void engineStarted(IExecutionEngine executionEngine) {
+	override void engineStarted(IExecutionEngine<?> executionEngine) {
 		val Activator activator = Activator.getDefault()
 		activator.debuggerSupplier = [this]
 		super.engineStarted(executionEngine)
@@ -215,12 +215,12 @@ public class OmniscientGenericSequentialModelDebugger extends GenericSequentialM
 		traceExplorer.registerCommand(this, [|update])
 	}
 
-	override void engineAboutToStop(IExecutionEngine engine) {
+	override void engineAboutToStop(IExecutionEngine<?> engine) {
 		traceExplorer.loadLastState
 		super.engineAboutToStop(engine)
 	}
 
-	override void engineStopped(IExecutionEngine executionEngine) {
+	override void engineStopped(IExecutionEngine<?> executionEngine) {
 		val Activator activator = Activator.getDefault()
 		activator.debuggerSupplier = null
 		super.engineStopped(executionEngine)

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
@@ -28,5 +28,4 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.executionframework.engine.ui,
- org.eclipse.gemoc.executionframework.engine.ui.commons,
  org.eclipse.gemoc.executionframework.engine.ui.launcher

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/AbstractGemocLauncher.java
@@ -11,9 +11,7 @@
 package org.eclipse.gemoc.executionframework.engine.ui.launcher;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
@@ -30,50 +28,46 @@ import org.eclipse.gemoc.executionframework.debugger.GenericSequentialModelDebug
 import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.IntrospectiveMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.OmniscientGenericSequentialModelDebugger;
-import org.eclipse.gemoc.executionframework.engine.ui.commons.RunConfiguration;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
+import org.eclipse.gemoc.executionframework.engine.core.RunConfiguration;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.trace.gemoc.api.IMultiDimensionalTraceAddon;
+import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
 
-abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI {
-	
-	public abstract IExecutionEngine getExecutionEngine(); 
+abstract public class AbstractGemocLauncher<C extends IExecutionContext<?, ?, ?>>
+		extends org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI {
 
-	// warning this MODEL_ID must be the same as the one in the ModelLoader in order to enable correctly the breakpoints
-	public final static String MODEL_ID = org.eclipse.gemoc.executionframework.engine.ui.Activator.PLUGIN_ID+".debugModel";
-	
-	public Map<String, Object> parseLaunchConfiguration(LaunchConfiguration launchConfiguration) {
-		return Collections.emptyMap();
-	}
-	
-	protected void openViewsRecommandedByAddons(IRunConfiguration runConfiguration){
-		for (EngineAddonSpecificationExtension extension : runConfiguration.getEngineAddonExtensions())
-		{
-			for(String viewId : extension.getOpenViewIds()){
+	public abstract IExecutionEngine<C> getExecutionEngine();
+
+	// warning this MODEL_ID must be the same as the one in the ModelLoader in order
+	// to enable correctly the breakpoints
+	public final static String MODEL_ID = org.eclipse.gemoc.executionframework.engine.ui.Activator.PLUGIN_ID
+			+ ".debugModel";
+
+	protected void openViewsRecommandedByAddons(IRunConfiguration runConfiguration) {
+		for (EngineAddonSpecificationExtension extension : runConfiguration.getEngineAddonExtensions()) {
+			for (String viewId : extension.getOpenViewIds()) {
 				ViewHelper.showView(viewId);
 			}
-			
 		}
 	}
-	
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	protected IDSLDebugger getDebugger(ILaunchConfiguration configuration, DSLDebugEventDispatcher dispatcher,
 			EObject firstInstruction, IProgressMonitor monitor) {
 
-		IExecutionEngine engine = (IExecutionEngine) getExecutionEngine();
+		IExecutionEngine<C> engine = getExecutionEngine();
 		AbstractGemocDebugger res;
-		Set<IMultiDimensionalTraceAddon> traceAddons = getExecutionEngine()
-				.getAddonsTypedBy(IMultiDimensionalTraceAddon.class);
+		Set<IMultiDimensionalTraceAddon> traceAddons = engine.getAddonsTypedBy(IMultiDimensionalTraceAddon.class);
 
 		// We don't want to use trace managers that only work with a subset of
 		// the execution state
 		traceAddons.removeIf(traceAddon -> {
-			return traceAddon.getTraceConstructor() != null && traceAddon.getTraceConstructor().isPartialTraceConstructor();
+			return traceAddon.getTraceConstructor() != null
+					&& traceAddon.getTraceConstructor().isPartialTraceConstructor();
 		});
 
 		if (traceAddons.isEmpty()) {
@@ -86,17 +80,17 @@ abstract public class AbstractGemocLauncher extends org.eclipse.gemoc.dsl.debug.
 		// We put annotation first
 		extractors.add(new AnnotationMutableFieldExtractor());
 		// Then introspection
-		extractors.add(new IntrospectiveMutableFieldExtractor(getExecutionEngine().getExecutionContext()
-				.getRunConfiguration().getLanguageName()));
+		extractors.add(new IntrospectiveMutableFieldExtractor(
+				getExecutionEngine().getExecutionContext().getRunConfiguration().getLanguageName()));
 		res.setMutableFieldExtractors(extractors);
 
 		// If in the launch configuration it is asked to pause at the start,
 		// we add this dummy break
 		try {
 			if (configuration.getAttribute(RunConfiguration.LAUNCH_BREAK_START, false)) {
-				res.addPredicateBreak(new BiPredicate<IExecutionEngine, Step<?>>() {
+				res.addPredicateBreak(new BiPredicate<IExecutionEngine<?>, Step<?>>() {
 					@Override
-					public boolean test(IExecutionEngine t, Step<?> u) {
+					public boolean test(IExecutionEngine<?> t, Step<?> u) {
 						return true;
 					}
 				});

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
@@ -17,7 +17,9 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.executionframework.event.model,
  org.eclipse.gemoc.executionframework.event.manager;bundle-version="2.4.0",
  org.eclipse.gemoc.dsl,
- org.eclipse.emf.ecore
+ org.eclipse.emf.ecore,
+ org.eclipse.debug.core,
+ org.eclipse.gemoc.dsl.debug.ide
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.executionframework.engine,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DefaultExecutionPlatform.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DefaultExecutionPlatform.java
@@ -23,64 +23,53 @@ import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonS
 import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtension;
 
 public class DefaultExecutionPlatform implements IExecutionPlatform {
-	
+
 	protected IModelLoader _modelLoader;
 	protected Collection<IEngineAddon> _addons;
-	
-	public DefaultExecutionPlatform(LanguageDefinitionExtension _languageDefinition, IRunConfiguration runConfiguration) throws CoreException 
-	{
+
+	public DefaultExecutionPlatform(LanguageDefinitionExtension _languageDefinition, IRunConfiguration runConfiguration) throws CoreException {
 		_modelLoader = _languageDefinition.instanciateModelLoader();
 		_addons = _languageDefinition.instanciateEngineAddons();
-		
-		for (EngineAddonSpecificationExtension extension : runConfiguration.getEngineAddonExtensions())
-		{
+
+		for (EngineAddonSpecificationExtension extension : runConfiguration.getEngineAddonExtensions()) {
 			addEngineAddon(extension.instanciateComponent());
 		}
-		for (IEngineAddon addon : _languageDefinition.instanciateEngineAddons())
-		{
-			addEngineAddon(addon);			
+		for (IEngineAddon addon : _languageDefinition.instanciateEngineAddons()) {
+			addEngineAddon(addon);
 		}
 	}
 
 	@Override
-	public IModelLoader getModelLoader() 
-	{
+	public IModelLoader getModelLoader() {
 		return _modelLoader;
 	}
 
 	@Override
-	public Iterable<IEngineAddon> getEngineAddons() 
-	{
-		synchronized(_addonLock)
-		{
+	public Iterable<IEngineAddon> getEngineAddons() {
+		synchronized (_addonLock) {
 			return Collections.unmodifiableCollection(new ArrayList<IEngineAddon>(_addons));
 		}
 	}
 
 	@Override
-	public void dispose() 
-	{
+	public void dispose() {
 		_addons.clear();
 	}
 
 	private Object _addonLock = new Object();
-	
+
 	@Override
-	public void addEngineAddon(IEngineAddon addon) 
-	{
-		synchronized (_addonLock) 
-		{
+	public void addEngineAddon(IEngineAddon addon) {
+		synchronized (_addonLock) {
 			_addons.add(addon);
 		}
 	}
 
 	@Override
-	public void removeEngineAddon(IEngineAddon addon) 
-	{
-		synchronized (_addonLock) 
-		{
+	public void removeEngineAddon(IEngineAddon addon) {
+		synchronized (_addonLock) {
 			_addons.remove(addon);
 		}
 	}
-	
+
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
@@ -11,8 +11,10 @@
  package org.eclipse.gemoc.executionframework.engine.core
 
 import org.eclipse.emf.transaction.RecordingCommand
+import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration
+import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext
 
-abstract class AbstractCommandBasedSequentialExecutionEngine extends AbstractSequentialExecutionEngine {
+abstract class AbstractCommandBasedSequentialExecutionEngine<C extends IExecutionContext<R, ?, ?>, R extends IRunConfiguration> extends AbstractSequentialExecutionEngine<C, R> {
 
 	/**
 	 * Must be called in a callback from the executed code from the operational

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -24,15 +24,14 @@ import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.impl.EMFCommandTransaction;
 import org.eclipse.emf.transaction.impl.InternalTransactionalEditingDomain;
 import org.eclipse.gemoc.executionframework.engine.Activator;
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.xdsmlframework.api.core.EngineStatus;
 import org.eclipse.gemoc.xdsmlframework.api.core.EngineStatus.RunStatus;
 import org.eclipse.gemoc.xdsmlframework.api.core.IDisposable;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
+import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
-
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
-import org.eclipse.gemoc.trace.commons.model.trace.Step;
 
 /**
  * Common implementation of {@link IExecutionEngine}. It provides the following
@@ -48,13 +47,13 @@ import org.eclipse.gemoc.trace.commons.model.trace.Step;
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
-public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisposable {
+public abstract class AbstractExecutionEngine<C extends IExecutionContext<R, ?, ?>, R extends IRunConfiguration> implements IExecutionEngine<C>, IDisposable {
 
 	private RunStatus _runningStatus = RunStatus.Initializing;
 
 	protected EngineStatus engineStatus = new EngineStatus();
 
-	protected IExecutionContext _executionContext;
+	protected C _executionContext;
 
 	protected boolean _started = false;
 	protected boolean _isStopped = false;
@@ -70,14 +69,14 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 
 	abstract protected void performStop();
 
-	abstract protected void performInitialize(IExecutionContext executionContext);
+	abstract protected void performInitialize(C executionContext);
 
 	abstract protected void beforeStart();
 
 	abstract protected void finishDispose();
 
 	@Override
-	public final void initialize(IExecutionContext executionContext) {
+	public final void initialize(C executionContext) {
 		if (executionContext == null)
 			throw new IllegalArgumentException("executionContext");
 		_executionContext = executionContext;
@@ -93,7 +92,7 @@ public abstract class AbstractExecutionEngine implements IExecutionEngine, IDisp
 	 * getExecutionContext()
 	 */
 	@Override
-	public final IExecutionContext getExecutionContext() {
+	public final C getExecutionContext() {
 		return _executionContext;
 	}
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.executionframework.engine.core;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
@@ -22,8 +21,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.gemoc.executionframework.engine.Activator;
-import org.eclipse.gemoc.executionframework.event.manager.EventManager;
-import org.eclipse.gemoc.executionframework.event.manager.IEventManager;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericSequentialStep;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictraceFactory;
 import org.eclipse.gemoc.trace.commons.model.trace.GenericMSE;
@@ -34,7 +31,7 @@ import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.trace.commons.model.trace.TraceFactory;
 import org.eclipse.gemoc.trace.gemoc.api.IMultiDimensionalTraceAddon;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext;
-import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
+import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 
 /**
  * Abstract class providing a basic implementation for sequential engines
@@ -42,11 +39,10 @@ import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
-public abstract class AbstractSequentialExecutionEngine extends AbstractExecutionEngine implements IExecutionEngine {
+public abstract class AbstractSequentialExecutionEngine<C extends IExecutionContext<R, ?, ?>, R extends IRunConfiguration> extends AbstractExecutionEngine<C, R> {
 
 	private MSEModel _actionModel;
 	private IMultiDimensionalTraceAddon<?, ?, ?, ?, ?> traceAddon;
-	private IEventManager eventManager;
 
 	protected abstract void executeEntryPoint();
 
@@ -56,25 +52,26 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 	protected abstract void initializeModel();
 
 	/**
-	 * search for an applicable entry point for the simulation, this is typically a method having the @Main annotation
-	 * @param executionContext the execution context of the simulation
+	 * search for an applicable entry point for the simulation, this is typically a
+	 * method having the @Main annotation
+	 * 
+	 * @param executionContext
+	 *            the execution context of the simulation
 	 */
-	protected abstract void prepareEntryPoint(IExecutionContext executionContext);
+	protected abstract void prepareEntryPoint(C executionContext);
 
 	/**
 	 * search for an applicable method tagged as @Initialize
 	 */
-	protected abstract void prepareInitializeModel(IExecutionContext executionContext);
+	protected abstract void prepareInitializeModel(C executionContext);
 
 	@Override
-	public final void performInitialize(IExecutionContext executionContext) {
+	public final void performInitialize(C executionContext) {
 		@SuppressWarnings("rawtypes")
 		Set<IMultiDimensionalTraceAddon> traceManagers = this.getAddonsTypedBy(IMultiDimensionalTraceAddon.class);
 		if (!traceManagers.isEmpty()) {
 			this.traceAddon = traceManagers.iterator().next();
 		}
-		eventManager = new EventManager();
-		getExecutionContext().getExecutionPlatform().addEngineAddon(eventManager);
 		prepareEntryPoint(executionContext);
 		prepareInitializeModel(executionContext);
 	}
@@ -87,15 +84,8 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 		Activator.getDefault().info("Execution finished");
 	}
 
-	private void manageEvents() {
-		if (eventManager != null) {
-			eventManager.processEvents();
-		}
-	}
-
 	@Override
 	protected final void afterExecutionStep() {
-		manageEvents();
 		super.afterExecutionStep();
 	}
 
@@ -117,8 +107,8 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 	}
 
 	/**
-	 * To be called just after each execution step by an implementing engine. If
-	 * the step was done through a RecordingCommand, it can be given.
+	 * To be called just after each execution step by an implementing engine. If the
+	 * step was done through a RecordingCommand, it can be given.
 	 */
 	protected final void beforeExecutionStep(Object caller, String className, String operationName, RecordingCommand rc) {
 		if (caller != null && caller instanceof EObject && editingDomain != null) {
@@ -126,8 +116,6 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 			EObject callerCast = (EObject) caller;
 			// We create a step
 			Step<?> step = createStep(callerCast, className, operationName);
-
-			manageEvents();
 
 			beforeExecutionStep(step, rc);
 		}
@@ -184,11 +172,16 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 	}
 
 	/**
-	 * Find the MSE element for the triplet caller/className/MethodName in the model of precalculated possible MSE.
-	 * If it doesn't exist yet, create one and add it to the model.
-	 * @param caller the caller object
-	 * @param className the class containing the method
-	 * @param methodName the name of the method
+	 * Find the MSE element for the triplet caller/className/MethodName in the model
+	 * of precalculated possible MSE. If it doesn't exist yet, create one and add it
+	 * to the model.
+	 * 
+	 * @param caller
+	 *            the caller object
+	 * @param className
+	 *            the class containing the method
+	 * @param methodName
+	 *            the name of the method
 	 * @return the retrieved or created MSE
 	 */
 	public final MSE findOrCreateMSE(EObject caller, String className, String methodName) {
@@ -242,16 +235,16 @@ public abstract class AbstractSequentialExecutionEngine extends AbstractExecutio
 
 	@Override
 	protected void beforeStart() {
-		
+
 	}
 
 	@Override
 	protected void performStop() {
-		
+
 	}
 
 	@Override
 	protected void finishDispose() {
-		
+
 	}
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/GemocRunningEnginesRegistry.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/GemocRunningEnginesRegistry.java
@@ -22,7 +22,7 @@ public class GemocRunningEnginesRegistry {
 	/**
 	 * List of engines that have registered to be running in this eclipse
 	 */
-	protected HashMap<String, IExecutionEngine> runningEngines = new HashMap<String, IExecutionEngine>();
+	protected HashMap<String, IExecutionEngine<?>> runningEngines = new HashMap<String, IExecutionEngine<?>>();
 	
 	
 	/**
@@ -31,7 +31,7 @@ public class GemocRunningEnginesRegistry {
 	 * @param engine to add
 	 * @return the unique name really used for this engine
 	 */
-	 public synchronized String registerEngine(String baseName, IExecutionEngine engine){
+	 public synchronized String registerEngine(String baseName, IExecutionEngine<?> engine){
 		int uniqueInstance = 0;
 		String engineName = Thread.currentThread().getName() + " ("+uniqueInstance+")";
 		synchronized(runningEngines)
@@ -50,7 +50,7 @@ public class GemocRunningEnginesRegistry {
 	{
 		synchronized(runningEngines)
 		{
-			IExecutionEngine engine = runningEngines.get(engineName);
+			IExecutionEngine<?> engine = runningEngines.get(engineName);
 			if (engine != null)
 			{
 				runningEngines.remove(engineName);
@@ -59,17 +59,17 @@ public class GemocRunningEnginesRegistry {
 		}
 	}
 
-	public HashMap<String, IExecutionEngine> getRunningEngines() {
+	public HashMap<String, IExecutionEngine<?>> getRunningEngines() {
 		synchronized(runningEngines)
 		{
-			return new HashMap<String, IExecutionEngine>(runningEngines);			
+			return new HashMap<String, IExecutionEngine<?>>(runningEngines);			
 		}
 	}
 	
 	
 	private List<IEngineRegistrationListener> _engineRegistrationListeners = new ArrayList<IEngineRegistrationListener>();
 	
-	private void notifyEngineRegistered(IExecutionEngine engine) {
+	private void notifyEngineRegistered(IExecutionEngine<?> engine) {
 		synchronized (_engineRegistrationListeners) {
 			for (IEngineRegistrationListener l : _engineRegistrationListeners)
 			{
@@ -78,7 +78,7 @@ public class GemocRunningEnginesRegistry {
 		}
 	}
 	
-	private void notifyEngineUnregistered(IExecutionEngine engine) {
+	private void notifyEngineUnregistered(IExecutionEngine<?> engine) {
 		synchronized (_engineRegistrationListeners) {
 			for (IEngineRegistrationListener l : _engineRegistrationListeners)
 			{

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/IEngineRegistrationListener.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/IEngineRegistrationListener.java
@@ -24,12 +24,12 @@ public interface IEngineRegistrationListener {
 	 * method called by the registry when an engine is registered
 	 * @param engine the registered engine
 	 */
-	void engineRegistered(IExecutionEngine engine);
+	void engineRegistered(IExecutionEngine<?> engine);
 
 	/**
 	 * method called by the registry when an engine is unregistered
 	 * @param engine the unregistered engine
 	 */
-	void engineUnregistered(IExecutionEngine engine);
+	void engineUnregistered(IExecutionEngine<?> engine);
 	
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
-package org.eclipse.gemoc.executionframework.engine.ui.commons;
+package org.eclipse.gemoc.executionframework.engine.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,11 +18,10 @@ import java.util.Map.Entry;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtensionPoint;
-
-import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
 
 public class RunConfiguration implements IRunConfiguration {
 
@@ -31,23 +30,18 @@ public class RunConfiguration implements IRunConfiguration {
 	public RunConfiguration(ILaunchConfiguration launchConfiguration) throws CoreException {
 		_launchConfiguration = launchConfiguration;
 		extractInformation();
-
 	}
 
 	protected void extractInformation() throws CoreException {
 		_languageName = getAttribute(LAUNCH_SELECTED_LANGUAGE, "");
-		_modelURI = URI.createPlatformResourceURI(getAttribute(AbstractDSLLaunchConfigurationDelegate.RESOURCE_URI, ""),
-				true);
+		_modelURI = URI.createPlatformResourceURI(getAttribute(AbstractDSLLaunchConfigurationDelegate.RESOURCE_URI, ""), true);
 		String animatorURIAsString = getAttribute("airdResource", "");
 		if (animatorURIAsString != null && !animatorURIAsString.equals("")) {
 			_animatorURI = URI.createPlatformResourceURI(animatorURIAsString, true);
 			_animationDelay = getAttribute(LAUNCH_DELAY, 0);
 		}
-		_deadlockDetectionDepth = getAttribute(LAUNCH_DEADLOCK_DETECTION_DEPTH, 10);
-		_methodEntryPoint = getAttribute(LAUNCH_METHOD_ENTRY_POINT, "");
-		_modelEntryPoint = getAttribute(LAUNCH_MODEL_ENTRY_POINT, "");
-		_modelInitializationMethod = getAttribute(LAUNCH_INITIALIZATION_METHOD, "");
-		_modelInitializationArguments = getAttribute(LAUNCH_INITIALIZATION_ARGUMENTS, "");
+		// TODO
+		// _deadlockDetectionDepth = getAttribute(LAUNCH_DEADLOCK_DETECTION_DEPTH, 10);
 		_melangeQuery = getAttribute(LAUNCH_MELANGE_QUERY, "");
 
 		for (EngineAddonSpecificationExtension extension : EngineAddonSpecificationExtensionPoint.getSpecifications()) {
@@ -105,13 +99,6 @@ public class RunConfiguration implements IRunConfiguration {
 		return _animatorURI;
 	}
 
-	private int _deadlockDetectionDepth = 0;
-
-	@Override
-	public int getDeadlockDetectionDepth() {
-		return _deadlockDetectionDepth;
-	}
-
 	private HashMap<EngineAddonSpecificationExtension, Boolean> _engineAddonExtensions = new HashMap<>();
 
 	@Override
@@ -124,38 +111,20 @@ public class RunConfiguration implements IRunConfiguration {
 		return result;
 	}
 
-	private String _methodEntryPoint;
-	private String _modelEntryPoint;
 	private String _languageName;
-
-	@Override
-	public String getExecutionEntryPoint() {
-		return _methodEntryPoint;
-	}
-
-	@Override
-	public String getModelEntryPoint() {
-		return _modelEntryPoint;
-	}
 
 	@Override
 	public String getLanguageName() {
 		return _languageName;
 	}
 
-	private String _modelInitializationMethod;
+	// TODO
+	// private int _deadlockDetectionDepth = 0;
 
-	@Override
-	public String getModelInitializationMethod() {
-		return _modelInitializationMethod;
-	}
-
-	private String _modelInitializationArguments;
-
-	@Override
-	public String getModelInitializationArguments() {
-		return _modelInitializationArguments;
-	}
+	// @Override
+	// public int getDeadlockDetectionDepth() {
+	// return _deadlockDetectionDepth;
+	// }
 
 	private boolean _breakStart;
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/SequentialExecutionException.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/SequentialExecutionException.xtend
@@ -10,9 +10,8 @@
  *******************************************************************************/
  package org.eclipse.gemoc.executionframework.engine.core;
 
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence
-import org.eclipse.gemoc.trace.commons.model.trace.Step
 import org.eclipse.emf.transaction.RollbackException
+import org.eclipse.gemoc.trace.commons.model.trace.Step
 
 /**
  * An exception that is caused by anything thrown from the execution of

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/src/org/eclipse/gemoc/executionframework/event/manager/EventManager.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/src/org/eclipse/gemoc/executionframework/event/manager/EventManager.java
@@ -80,7 +80,7 @@ public class EventManager implements IEventManager {
 	}
 
 	@Override
-	public void engineAboutToStart(IExecutionEngine engine) {
+	public void engineAboutToStart(IExecutionEngine<?> engine) {
 		final Set<IBehavioralAPI> apis = engine.getAddonsTypedBy(IBehavioralAPI.class);
 		if (!apis.isEmpty()) {
 			api = apis.iterator().next();

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/src/org/eclipse/gemoc/executionframework/event/ui/views/EventManagerRenderer.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/src/org/eclipse/gemoc/executionframework/event/ui/views/EventManagerRenderer.java
@@ -190,12 +190,12 @@ public class EventManagerRenderer extends Pane implements IEngineAddon {
 	}
 
 	@Override
-	public void engineStarted(IExecutionEngine executionEngine) {
+	public void engineStarted(IExecutionEngine<?> executionEngine) {
 		executedModel = executionEngine.getExecutionContext().getResourceModel();
 	}
 
 	@Override
-	public void engineInitialized(IExecutionEngine executionEngine) {
+	public void engineInitialized(IExecutionEngine<?> executionEngine) {
 		Set<IEventManager> eventManagers = executionEngine.getAddonsTypedBy(IEventManager.class);
 		if (!eventManagers.isEmpty()) {
 			setEventInterpreter(eventManagers.iterator().next());
@@ -203,7 +203,7 @@ public class EventManagerRenderer extends Pane implements IEngineAddon {
 	}
 
 	@Override
-	public void engineStopped(IExecutionEngine engine) {
+	public void engineStopped(IExecutionEngine<?> engine) {
 		executedModel = null;
 		eventTypeToEventTableView.clear();
 		Platform.runLater(() -> {
@@ -213,12 +213,12 @@ public class EventManagerRenderer extends Pane implements IEngineAddon {
 	}
 
 	@Override
-	public void aboutToExecuteStep(IExecutionEngine engine, Step<?> stepToExecute) {
+	public void aboutToExecuteStep(IExecutionEngine<?> engine, Step<?> stepToExecute) {
 		refreshEvents();
 	}
 
 	@Override
-	public void stepExecuted(IExecutionEngine engine, Step<?> stepExecuted) {
+	public void stepExecuted(IExecutionEngine<?> engine, Step<?> stepExecuted) {
 		refreshEvents();
 	}
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/src/org/eclipse/gemoc/executionframework/event/ui/views/EventManagerViewPart.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/src/org/eclipse/gemoc/executionframework/event/ui/views/EventManagerViewPart.java
@@ -44,7 +44,7 @@ public class EventManagerViewPart extends EngineSelectionDependentViewPart {
 	}
 
 	@Override
-	public void engineSelectionChanged(IExecutionEngine engine) {
+	public void engineSelectionChanged(IExecutionEngine<?> engine) {
 		if (engine != null) {
 			eventManagerRenderer.setExecutedModel(engine.getExecutionContext().getResourceModel());
 			engine.getExecutionContext().getExecutionPlatform().addEngineAddon(eventManagerRenderer);

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/Activator.java
@@ -48,11 +48,11 @@ public class Activator extends AbstractUIPlugin {
 				// activePage.closeEditors(activePage.getEditorReferences(), false);
 				
 				// try to close only Sirius sessions related to engines
-				for (Entry<String, IExecutionEngine> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet())
+				for (Entry<String, IExecutionEngine<?>> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet())
 			    {	
 					try{
 						// stop any running engine
-						IExecutionEngine engine = engineEntry.getValue();
+						IExecutionEngine<?> engine = engineEntry.getValue();
 						if(engine.getRunningStatus() != RunStatus.Stopped){
 							
 							engine.dispose();

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
@@ -110,7 +110,7 @@ public class DefaultModelLoader implements IModelLoader {
 	 * @throws RuntimeException
 	 *             if anything goes wrong (eg. the model cannot be found).
 	 */
-	public Resource loadModel(IExecutionContext context) throws RuntimeException {
+	public Resource loadModel(IExecutionContext<?, ?, ?> context) throws RuntimeException {
 		return loadModel(context, false, progressMonitor);
 	}
 
@@ -124,7 +124,7 @@ public class DefaultModelLoader implements IModelLoader {
 	 * @throws RuntimeException
 	 *             if anything goes wrong (eg. the model cannot be found)
 	 */
-	public Resource loadModelForAnimation(IExecutionContext context) throws RuntimeException {
+	public Resource loadModelForAnimation(IExecutionContext<?, ?, ?> context) throws RuntimeException {
 		return loadModel(context, true, progressMonitor);
 	}
 
@@ -141,7 +141,7 @@ public class DefaultModelLoader implements IModelLoader {
 	 * @throws RuntimeException
 	 *             if anything goes wrong (eg. the model cannot be found)
 	 */
-	private static Resource loadModel(IExecutionContext context, boolean withAnimation, IProgressMonitor progressMonitor) throws RuntimeException {
+	private static Resource loadModel(IExecutionContext<?, ?, ?> context, boolean withAnimation, IProgressMonitor progressMonitor) throws RuntimeException {
 
 		// Common part: preparing URI + resource set
 		SubMonitor subMonitor = SubMonitor.convert(progressMonitor, 10);
@@ -224,7 +224,7 @@ public class DefaultModelLoader implements IModelLoader {
 		}
 	}
 
-	private static Session openNewSiriusSession(final IExecutionContext context, URI sessionResourceURI, ResourceSet rs,
+	private static Session openNewSiriusSession(final IExecutionContext<?, ?, ?> context, URI sessionResourceURI, ResourceSet rs,
 			URI modelURI, SubMonitor subMonitor, HashMap<String, String> nsURIMapping) throws CoreException {
 
 		subMonitor.subTask("Loading model");
@@ -407,7 +407,7 @@ public class DefaultModelLoader implements IModelLoader {
 
 	// TODO must be extended to support more complex mappings, currently use
 	// only the first package in the genmodel
-	protected static HashMap<String, String> getnsURIMapping(IExecutionContext context) {
+	protected static HashMap<String, String> getnsURIMapping(IExecutionContext<?, ?, ?> context) {
 		HashMap<String, String> nsURIMapping = new HashMap<String, String>();
 
 		final String langQuery = "lang=";

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/services/AbstractGemocAnimatorServices.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/services/AbstractGemocAnimatorServices.java
@@ -318,24 +318,24 @@ public abstract class AbstractGemocAnimatorServices {
 		}
 
 		@Override
-		public void engineAboutToStart(IExecutionEngine engine) {
+		public void engineAboutToStart(IExecutionEngine<?> engine) {
 		}
 
 		@Override
-		public void engineStarted(IExecutionEngine executionEngine) {
+		public void engineStarted(IExecutionEngine<?> executionEngine) {
 		}
 
 		@Override
-		public void engineAboutToStop(IExecutionEngine engine) {
+		public void engineAboutToStop(IExecutionEngine<?> engine) {
 		}
 
 		@Override
-		public void engineStopped(IExecutionEngine engine) {
+		public void engineStopped(IExecutionEngine<?> engine) {
 			clear(engine);
 		}
 
 		@Override
-		public void engineStatusChanged(IExecutionEngine engine, RunStatus newStatus) {
+		public void engineStatusChanged(IExecutionEngine<?> engine, RunStatus newStatus) {
 		}
 
 		/**
@@ -363,11 +363,11 @@ public abstract class AbstractGemocAnimatorServices {
 		}
 
 		@Override
-		public void proposedStepsChanged(IExecutionEngine engine, Collection<Step<?>> logicalSteps) {
+		public void proposedStepsChanged(IExecutionEngine<?> engine, Collection<Step<?>> logicalSteps) {
 		}
 
 		@Override
-		public void engineAboutToDispose(IExecutionEngine engine) {
+		public void engineAboutToDispose(IExecutionEngine<?> engine) {
 			if (engine.getExecutionContext().getRunConfiguration()
 					.getAnimatorURI() != null) {
 				Session session = SessionManager.INSTANCE.getSession(engine
@@ -384,22 +384,22 @@ public abstract class AbstractGemocAnimatorServices {
 		}
 
 		@Override
-		public void aboutToSelectStep(IExecutionEngine engine, Collection<Step<?>> logicalSteps) {
+		public void aboutToSelectStep(IExecutionEngine<?> engine, Collection<Step<?>> logicalSteps) {
 		}
 
 		@Override
-		public void stepSelected(IExecutionEngine engine, Step<?> selectedLogicalStep) {
+		public void stepSelected(IExecutionEngine<?> engine, Step<?> selectedLogicalStep) {
 		}
 
 		@Override
-		public void aboutToExecuteStep(IExecutionEngine engine, Step<?> stepToExecute) {
+		public void aboutToExecuteStep(IExecutionEngine<?> engine, Step<?> stepToExecute) {
 			if(!(stepToExecute.eContainer() instanceof ParallelStep)){
 				activate(engine, stepToExecute);
 			}
 		}
 
 		@Override
-		public void stepExecuted(IExecutionEngine engine, Step<?> stepExecuted) {
+		public void stepExecuted(IExecutionEngine<?> engine, Step<?> stepExecuted) {
 		}
 	}
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionDependentViewPart.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionDependentViewPart.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.gemoc.executionframework.ui.views.engine;
 
+import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
+import org.eclipse.gemoc.executionframework.ui.Activator;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ViewPart;
-import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
-import org.eclipse.gemoc.executionframework.ui.Activator;
 
 /**
  * Views that are dependent on the engine selection in the EnginesStatusView may subclass this to get registered to it

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
@@ -61,7 +61,7 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 
 	public TreeViewer _viewer;
 	private ViewContentProvider _contentProvider;
-	
+
 	/**
 	 * The constructor.
 	 */
@@ -70,395 +70,361 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 
 	@Override
 	public void dispose() {
-//		org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.deleteObserver(this);
+		// org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.deleteObserver(this);
 		org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.removeEngineRegistrationListener(this);
 		super.dispose();
 	}
-	
+
 	/**
-	 * This is a callback that will allow us
-	 * to create the viewer and initialize it.
+	 * This is a callback that will allow us to create the viewer and initialize it.
 	 */
 	public void createPartControl(Composite parent) {
 		_viewer = new TreeViewer(parent, SWT.FULL_SELECTION | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
 		_contentProvider = new ViewContentProvider();
 		_viewer.setContentProvider(_contentProvider);
 		ColumnViewerToolTipSupport.enableFor(_viewer);
-		_viewer.addSelectionChangedListener(
-				new ISelectionChangedListener() {
-					public void selectionChanged(SelectionChangedEvent event) {
-						fireEngineSelectionChanged();
-					}
-				});
-		
+		_viewer.addSelectionChangedListener(new ISelectionChangedListener() {
+			public void selectionChanged(SelectionChangedEvent event) {
+				fireEngineSelectionChanged();
+			}
+		});
+
 		createColumns();
-//		_viewer.setColumnProperties( new String[] {"Status", "Identifier", "Step", "Status"} );
-//		_viewer.getTree().setHeaderVisible(true);
+		// _viewer.setColumnProperties( new String[] {"Status", "Identifier", "Step",
+		// "Status"} );
+		// _viewer.getTree().setHeaderVisible(true);
 		Font mono = JFaceResources.getFont(JFaceResources.TEXT_FONT);
 		_viewer.getTree().setFont(mono);
-		
+
 		// Create the help context id for the viewer's control
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(_viewer.getControl(), "org.eclipse.gemoc.executionframework.ui.views.engine.EngineStatusView");
-			
+
 		// register for changes in the RunningEngineRegistry
-		//org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.addObserver(this);
-		
-		buildMenu();		
+		// org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.addObserver(this);
+
+		buildMenu();
 
 		org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.addEngineRegistrationListener(this);
 	}
 
-	private void buildMenu()
-	{
-		//addActionToToolbar(new PauseResumeEngineDeciderAction());
+	private void buildMenu() {
+		// addActionToToolbar(new PauseResumeEngineDeciderAction());
 		addActionToToolbar(new StopEngineAction());
 		addActionToToolbar(new DisposeStoppedEngineAction());
 		addActionToToolbar(new DisposeAllStoppedEnginesAction());
-		//addSeparatorToToolbar();
-		//addActionToToolbar(new SwitchDeciderAction());
+		// addSeparatorToToolbar();
+		// addActionToToolbar(new SwitchDeciderAction());
 	}
-	
-	private void addActionToToolbar(Action action)
-	{
+
+	private void addActionToToolbar(Action action) {
 		IActionBars actionBars = getViewSite().getActionBars();
-//		IMenuManager dropDownMenu = actionBars.getMenuManager();
+		// IMenuManager dropDownMenu = actionBars.getMenuManager();
 		IToolBarManager toolBar = actionBars.getToolBarManager();
-//		dropDownMenu.add(action);
-		toolBar.add(action);	
+		// dropDownMenu.add(action);
+		toolBar.add(action);
 	}
 
 	/*
-	private void addSeparatorToToolbar()
-	{
-		IActionBars actionBars = getViewSite().getActionBars();
-//		IMenuManager dropDownMenu = actionBars.getMenuManager();
-		IToolBarManager toolBar = actionBars.getToolBarManager();
-//		dropDownMenu.add(action);
-		toolBar.add(new Separator());		
-	}
-	*/
+	 * private void addSeparatorToToolbar() { IActionBars actionBars =
+	 * getViewSite().getActionBars(); // IMenuManager dropDownMenu =
+	 * actionBars.getMenuManager(); IToolBarManager toolBar =
+	 * actionBars.getToolBarManager(); // dropDownMenu.add(action); toolBar.add(new
+	 * Separator()); }
+	 */
 
 	/**
-	 * used by createPartControl
-	 * Creates the columns in the view
+	 * used by createPartControl Creates the columns in the view
+	 * 
 	 * @param viewer
 	 */
-	private void createColumns() 
-	{
+	private void createColumns() {
 		createColumn1();
 		createColumn2();
 		createColumn3();
-//		createColumn4();
+		// createColumn4();
 	}
-	
-	private void createColumn1() 
-	{
+
+	private void createColumn1() {
 		TreeColumn column = new TreeColumn(_viewer.getTree(), SWT.LEFT);
-		//column.setText("Status");
+		// column.setText("Status");
 		TreeViewerColumn viewerColumn = new TreeViewerColumn(_viewer, column);
-		viewerColumn.setLabelProvider(
-			new ColumnLabelProvider()
-			{
-				@Override
-				public String getText(Object element) {
-					return null;
+		viewerColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return null;
+			}
+
+			@Override
+			public Image getImage(Object element) {
+				Image result = null;
+				if (element instanceof IExecutionEngine) {
+					IExecutionEngine<?> engine = (IExecutionEngine<?>) element;
+					switch (engine.getRunningStatus()) {
+					case Running:
+						result = SharedIcons.getSharedImage(SharedIcons.RUNNING_ENGINE_ICON);
+						break;
+
+					case Stopped:
+						result = SharedIcons.getSharedImage(SharedIcons.STOPPED_ENGINE_ICON);
+						break;
+
+					case WaitingLogicalStepSelection:
+						result = SharedIcons.getSharedImage(SharedIcons.WAITING_ENGINE_ICON);
+						break;
+
+					case Initializing:
+						result = SharedIcons.getSharedImage(SharedIcons.ENGINE_ICON);
+						break;
+
+					default:
+						break;
+					}
 				}
-				
-				@Override
-				public Image getImage(Object element) 
-				{
-					Image result = null;
-					if (element instanceof IExecutionEngine)
-					{
-						IExecutionEngine engine = (IExecutionEngine)element;
-						switch (engine.getRunningStatus()) {
-							case Running:
-								result = SharedIcons.getSharedImage(SharedIcons.RUNNING_ENGINE_ICON);							
-								break;
-	
-							case Stopped:
-								result = SharedIcons.getSharedImage(SharedIcons.STOPPED_ENGINE_ICON);							
-								break;
+				return result;
+			}
+		});
+	}
 
-							case WaitingLogicalStepSelection:
-								result = SharedIcons.getSharedImage(SharedIcons.WAITING_ENGINE_ICON);							
-								break;
+	private void createColumn2() {
+		TreeColumn column = new TreeColumn(_viewer.getTree(), SWT.LEFT);
+		// column.setText("Identifier");
+		TreeViewerColumn viewerColumn = new TreeViewerColumn(_viewer, column);
+		viewerColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				String result = "";
+				if (element instanceof IExecutionEngine) {
+					IExecutionEngine<?> engine = (IExecutionEngine<?>) element;
+					result = engine.getExecutionContext().getResourceModel().getURI().segmentsList().get(engine.getExecutionContext().getResourceModel().getURI().segments().length - 1);
+				}
+				return result;
+			}
 
-							case Initializing:
-								result = SharedIcons.getSharedImage(SharedIcons.ENGINE_ICON);							
-								break;
+			@Override
+			public Image getImage(Object element) {
+				Image result = null;
+				// ImageDescriptor imageDescriptor = null;
+				// DVK note: we could replace that by a better api in the engine context so it
+				// could offer an icon dedicated to the engine kind
+				// if (element instanceof INonDeterministicExecutionEngine)
+				// {
+				// INonDeterministicExecutionEngine engine =
+				// (INonDeterministicExecutionEngine)element;
+				// for (DeciderSpecificationExtension spec :
+				// DeciderSpecificationExtensionPoint.getSpecifications())
+				// {
+				// if
+				// (engine.getLogicalStepDecider().getClass().getName().equals(spec.getDeciderClassName()))
+				// {
+				// imageDescriptor = ImageDescriptor.createFromURL(spec.getIconURL());
+				// break;
+				// }
+				// }
+				// }
+				// if (imageDescriptor != null)
+				// {
+				// result = imageDescriptor.createImage();
+				// }
+				return result;
+			}
 
-							default:
-								break;
+			@Override
+			public String getToolTipText(Object element) {
+				String result = "";
+				if (element instanceof IExecutionEngine) {
+					IExecutionEngine<?> engine = (IExecutionEngine<?>) element;
+					GemocRunningEnginesRegistry registry = org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry;
+					for (Entry<String, IExecutionEngine<?>> e : registry.getRunningEngines().entrySet()) {
+						if (e.getValue() == engine) {
+							result = e.getKey();
+							break;
 						}
 					}
-					return result;
-				}			
-			});	
-	}
-	
-	private void createColumn2() 
-	{
-		TreeColumn column = new TreeColumn(_viewer.getTree(), SWT.LEFT);
-//		column.setText("Identifier");
-		TreeViewerColumn viewerColumn = new TreeViewerColumn(_viewer, column);
-		viewerColumn.setLabelProvider(
-			new ColumnLabelProvider()
-			{	
-				@Override
-				public String getText(Object element) 
-				{
-					String result = "";
-					if (element instanceof IExecutionEngine)
-					{					
-						IExecutionEngine engine = (IExecutionEngine)element;
-						result = engine.getExecutionContext().getResourceModel().getURI().segmentsList().get(engine.getExecutionContext().getResourceModel().getURI().segments().length-1);	
+					result += "\n";
+					switch (engine.getRunningStatus()) {
+					case Initializing:
+						result += "Initializing";
+						break;
+					case Running:
+						result += "Running";
+						break;
+					case WaitingLogicalStepSelection:
+						result += "Waiting LogicalStep Selection";
+						break;
+					case Stopped:
+						result += "Stopped";
+						break;
 					}
-					return result;
+					result += "\n";
+					result += "Step " + engine.getEngineStatus().getNbLogicalStepRun();
 				}
-			
-				@Override
-				public Image getImage(Object element) 
-				{
-					Image result = null;
-//					ImageDescriptor imageDescriptor = null;
-// DVK note: we could replace that by a better api in the engine context so it could offer an icon dedicated to the engine kind					
-//					if (element instanceof INonDeterministicExecutionEngine)
-//					{
-//						INonDeterministicExecutionEngine engine = (INonDeterministicExecutionEngine)element;
-//						for (DeciderSpecificationExtension spec : DeciderSpecificationExtensionPoint.getSpecifications())
-//						{
-//							if (engine.getLogicalStepDecider().getClass().getName().equals(spec.getDeciderClassName()))
-//							{
-//								imageDescriptor = ImageDescriptor.createFromURL(spec.getIconURL());
-//								break;
-//							}							
-//						}
-//					}
-//					if (imageDescriptor != null)
-//					{
-//						result = imageDescriptor.createImage();
-//					}
-					return result;
-				}
-				
-				@Override
-				public String getToolTipText(Object element) 
-				{
-					String result = "";
-					if (element instanceof IExecutionEngine)
-					{					
-						IExecutionEngine engine = (IExecutionEngine)element;
-						GemocRunningEnginesRegistry registry = org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry;
-						for (Entry<String, IExecutionEngine> e : registry.getRunningEngines().entrySet())
-						{
-							if (e.getValue() == engine)
-							{
-								result = e.getKey();
-								break;
-							}								
-						}
-						result += "\n";
-						switch(engine.getRunningStatus())
-						{
-							case Initializing : 
-								result += "Initializing";
-								break;
-							case Running:
-								result += "Running";
-								break;
-							case WaitingLogicalStepSelection:
-								result += "Waiting LogicalStep Selection";
-								break;
-							case Stopped:
-								result += "Stopped";
-								break;
-						}	
-						result += "\n";
-						result += "Step " + engine.getEngineStatus().getNbLogicalStepRun();
-					}
-					return result;
-				}				
-			});
+				return result;
+			}
+		});
 	}
 
-	private void createColumn3() 
-	{
+	private void createColumn3() {
 		TreeColumn column = new TreeColumn(_viewer.getTree(), SWT.LEFT);
-//		column.setText("Step");
+		// column.setText("Step");
 		TreeViewerColumn viewerColumn = new TreeViewerColumn(_viewer, column);
-		viewerColumn.setLabelProvider(
-			new ColumnLabelProvider()
-			{
-				@Override
-				public String getText(Object element) 
-				{
-					String result = "";
-					if (element instanceof IExecutionEngine)
-					{					
-						IExecutionEngine engine = (IExecutionEngine)element;
-						result = String.format("%d", engine.getEngineStatus().getNbLogicalStepRun());
-					}
-					return result;
-				}			
-			});
+		viewerColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				String result = "";
+				if (element instanceof IExecutionEngine) {
+					IExecutionEngine<?> engine = (IExecutionEngine<?>) element;
+					result = String.format("%d", engine.getEngineStatus().getNbLogicalStepRun());
+				}
+				return result;
+			}
+		});
 	}
-	
+
 	/**
 	 * Passing the focus request to the viewer's control.
 	 */
 	public void setFocus() {
 		_viewer.getControl().setFocus();
 	}
-	
+
 	/**
 	 * get the selection
+	 * 
 	 * @return the engine selected or null if no engine selected
 	 */
-	public IExecutionEngine getSelectedEngine()
-	{
-		try{
+	public IExecutionEngine<?> getSelectedEngine() {
+		try {
 			IStructuredSelection selection = (IStructuredSelection) _viewer.getSelection();
-			return (IExecutionEngine)selection.getFirstElement();
-		} catch(Exception e){
+			return (IExecutionEngine<?>) selection.getFirstElement();
+		} catch (Exception e) {
 			Activator.error(e.getMessage(), e);
 		}
 		return null;
 	}
-	
-	public void removeStoppedEngines(){
+
+	public void removeStoppedEngines() {
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-		    // we may be triggered by a registry change or by an engine change
-		    // if registry changes, then may need to observe the new engine
-		    for (Entry<String, IExecutionEngine> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet())
-		    {		    	  
-		    	switch(engineEntry.getValue().getRunningStatus())
-		    	{
-		    		case Stopped:
-		    			engineEntry.getValue().dispose();
-		    			org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.unregisterEngine(engineEntry.getKey());		    			
-		    			break;
-		    		default:
-		    	}		    	
-	    	}
-		    _viewer.setInput(org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry);
-	      }
-		 });
+				// we may be triggered by a registry change or by an engine change
+				// if registry changes, then may need to observe the new engine
+				for (Entry<String, IExecutionEngine<?>> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet()) {
+					switch (engineEntry.getValue().getRunningStatus()) {
+					case Stopped:
+						engineEntry.getValue().dispose();
+						org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.unregisterEngine(engineEntry.getKey());
+						break;
+					default:
+					}
+				}
+				_viewer.setInput(org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry);
+			}
+		});
 	}
 
-	private IExecutionEngine selectedEngine = null;
-	
+	private IExecutionEngine<?> selectedEngine = null;
+
 	private void fireEngineSelectionChanged() {
-		IExecutionEngine engine = getSelectedEngine();
+		IExecutionEngine<?> engine = getSelectedEngine();
 		if (engine != selectedEngine) {
 			selectedEngine = engine;
-			for(IEngineSelectionListener listener: Activator.getDefault().getEngineSelectionManager().getEngineSelectionListeners()) {
+			for (IEngineSelectionListener listener : Activator.getDefault().getEngineSelectionManager().getEngineSelectionListeners()) {
 				listener.engineSelectionChanged(selectedEngine);
 			}
 		}
 	}
 
 	@Override
-	public void engineRegistered(final IExecutionEngine engine) 
-	{
+	public void engineRegistered(final IExecutionEngine<?> engine) {
 		Display.getDefault().syncExec(new Runnable() {
-		      public void run() {
-		  		engine.getExecutionContext().getExecutionPlatform().addEngineAddon(EnginesStatusView.this);
-		    	_viewer.setInput(org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry);
-		    	TreeViewerHelper.resizeColumns(_viewer);
-	    		TreePath treePath = new TreePath(new Object[] {engine});
-	    		TreeSelection newSelection = new TreeSelection(treePath);
-	    		_viewer.setSelection(newSelection, true);			      }
-		 });
+			public void run() {
+				engine.getExecutionContext().getExecutionPlatform().addEngineAddon(EnginesStatusView.this);
+				_viewer.setInput(org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry);
+				TreeViewerHelper.resizeColumns(_viewer);
+				TreePath treePath = new TreePath(new Object[] { engine });
+				TreeSelection newSelection = new TreeSelection(treePath);
+				_viewer.setSelection(newSelection, true);
+			}
+		});
 	}
 
 	@Override
-	public void engineUnregistered(IExecutionEngine engine) 
-	{
+	public void engineUnregistered(IExecutionEngine<?> engine) {
 		engine.getExecutionContext().getExecutionPlatform().removeEngineAddon(this);
 	}
 
-	private void updateUserInterface(final IExecutionEngine engine) {
-    	_viewer.update(engine, null);
-    	TreeViewerHelper.resizeColumns(_viewer);    	
+	private void updateUserInterface(final IExecutionEngine<?> engine) {
+		_viewer.update(engine, null);
+		TreeViewerHelper.resizeColumns(_viewer);
 	}
 
-	private void reselectEngine(final IExecutionEngine engine)
-	{
+	private void reselectEngine(final IExecutionEngine<?> engine) {
 		Display.getDefault().syncExec(new Runnable() {
-		      public void run() {
-		    	  updateUserInterface(engine);
-		    	  if (getSelectedEngine() == engine)
-		    	  {
-		    		  fireEngineSelectionChanged();
-		    	  }
-		      }
-		 });
+			public void run() {
+				updateUserInterface(engine);
+				if (getSelectedEngine() == engine) {
+					fireEngineSelectionChanged();
+				}
+			}
+		});
 
-	}
-	
-	@Override
-	public void engineAboutToStart(IExecutionEngine engine) 
-	{
 	}
 
 	@Override
-	public void engineStarted(IExecutionEngine engine) 
-	{
+	public void engineAboutToStart(IExecutionEngine<?> engine) {
+	}
+
+	@Override
+	public void engineStarted(IExecutionEngine<?> engine) {
 		reselectEngine(engine);
 	}
 
 	@Override
-	public void aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> logicalStepToApply) 
-	{
+	public void aboutToExecuteStep(IExecutionEngine<?> executionEngine, Step<?> logicalStepToApply) {
 	}
 
 	@Override
-	public void engineAboutToStop(IExecutionEngine engine) {
+	public void engineAboutToStop(IExecutionEngine<?> engine) {
 		reselectEngine(engine);
 	}
 
 	@Override
-	public void engineStopped(IExecutionEngine engine) 
-	{
+	public void engineStopped(IExecutionEngine<?> engine) {
 		reselectEngine(engine);
 	}
 
 	@Override
-	public void aboutToSelectStep(IExecutionEngine engine, Collection<Step<?>> logicalSteps) 
-	{
+	public void aboutToSelectStep(IExecutionEngine<?> engine, Collection<Step<?>> logicalSteps) {
 		reselectEngine(engine);
 	}
 
 	@Override
-	public void stepSelected(IExecutionEngine engine, Step<?> selectedLogicalStep) {
+	public void stepSelected(IExecutionEngine<?> engine, Step<?> selectedLogicalStep) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
-	public void stepExecuted(IExecutionEngine engine, Step<?> logicalStepExecuted) {
+	public void stepExecuted(IExecutionEngine<?> engine, Step<?> logicalStepExecuted) {
 		reselectEngine(engine); // need to update the executed step count in the view
-		
+
 	}
 
 	@Override
-	public void engineStatusChanged(IExecutionEngine engine, RunStatus newStatus) {
+	public void engineStatusChanged(IExecutionEngine<?> engine, RunStatus newStatus) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
-	public void proposedStepsChanged(IExecutionEngine engine, Collection<Step<?>> logicalSteps) {
+	public void proposedStepsChanged(IExecutionEngine<?> engine, Collection<Step<?>> logicalSteps) {
 		reselectEngine(engine);
-		
+
 	}
 
 	@Override
-	public void engineAboutToDispose(IExecutionEngine engine) {
+	public void engineAboutToDispose(IExecutionEngine<?> engine) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/IEngineSelectionListener.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/IEngineSelectionListener.java
@@ -18,6 +18,6 @@ public interface IEngineSelectionListener {
 	 * Notify when engine is selected by user.
 	 * @param engine The selected engine.
 	 */
-	public void engineSelectionChanged(IExecutionEngine engine);
+	public void engineSelectionChanged(IExecutionEngine<?> engine);
 	
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/actions/AbstractEngineAction.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/actions/AbstractEngineAction.java
@@ -66,13 +66,13 @@ public abstract class AbstractEngineAction extends Action  implements IMenuCreat
 	}
 	
 	
-	protected IExecutionEngine _currentSelectedEngine;
-	public IExecutionEngine getCurrentSelectedEngine(){
+	protected IExecutionEngine<?> _currentSelectedEngine;
+	public IExecutionEngine<?> getCurrentSelectedEngine(){
 		return _currentSelectedEngine;
 	}
 	
 	@Override
-	public void engineSelectionChanged(IExecutionEngine engine) 
+	public void engineSelectionChanged(IExecutionEngine<?> engine) 
 	{
 		_currentSelectedEngine = engine;
 		

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionContext.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionContext.java
@@ -16,25 +16,25 @@ import org.osgi.framework.Bundle;
 
 import org.eclipse.gemoc.trace.commons.model.trace.MSEModel;
 
-public interface IExecutionContext extends IDisposable
-{
+public interface IExecutionContext<R extends IRunConfiguration, P extends IExecutionPlatform, L extends LanguageDefinitionExtension>
+		extends IDisposable {
 
 	void initializeResourceModel();
-	
-	LanguageDefinitionExtension getLanguageDefinitionExtension();
-	
-	IExecutionWorkspace getWorkspace();
 
-	IExecutionPlatform getExecutionPlatform();
-	
-	IRunConfiguration getRunConfiguration();
+	IExecutionWorkspace getWorkspace();
 
 	Resource getResourceModel();
 
 	ExecutionMode getExecutionMode();
 
 	MSEModel getMSEModel();
-	
+
 	Bundle getDslBundle();
-	 
+
+	L getLanguageDefinitionExtension();
+
+	P getExecutionPlatform();
+
+	R getRunConfiguration();
+
 }

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionEngine.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionEngine.java
@@ -29,7 +29,7 @@ import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  * 
  */
-public interface IExecutionEngine extends IDisposable {
+public interface IExecutionEngine<U extends IExecutionContext<?, ?, ?>> extends IDisposable {
 	
 	/**
 	 * In case of nested calls, indicate the current stack of model specific event occurrences.
@@ -83,7 +83,7 @@ public interface IExecutionEngine extends IDisposable {
 	 * get the execution context
 	 * @return the {@link IExecutionContext}
 	 */
-	IExecutionContext getExecutionContext();
+	U getExecutionContext();
 
 	/**
 	 * get the run status
@@ -102,7 +102,7 @@ public interface IExecutionEngine extends IDisposable {
 	 * Ask the engine to initialize
 	 * @param executionContext the {@link IExecutionContext}
 	 */
-	void initialize(IExecutionContext executionContext);
+	void initialize(U executionContext);
 	
 	/**
 	 * Create a {@link LaunchConfiguration} for the Trace based on the engine RunConfiguration.

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionPlatform.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IExecutionPlatform.java
@@ -12,10 +12,7 @@ package org.eclipse.gemoc.xdsmlframework.api.core;
 
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 
-public interface IExecutionPlatform extends IDisposable
-{
-
-	
+public interface IExecutionPlatform extends IDisposable {
 
 	/**
 	 * @return The model loader used to load the model to be executed.
@@ -23,8 +20,9 @@ public interface IExecutionPlatform extends IDisposable
 	IModelLoader getModelLoader();
 
 	void addEngineAddon(IEngineAddon addon);
+
 	void removeEngineAddon(IEngineAddon addon);
+
 	Iterable<IEngineAddon> getEngineAddons();
-	
 
 }

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IModelLoader.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IModelLoader.java
@@ -22,9 +22,11 @@ import org.eclipse.emf.ecore.resource.Resource;
 public interface IModelLoader {
 
 	/** load Model when running in normal mode */
-	Resource loadModel(IExecutionContext context);
+	Resource loadModel(IExecutionContext<?, ?, ?> context);
+
 	/** load model when running in animation mode */
-	Resource loadModelForAnimation(IExecutionContext context);
+	Resource loadModelForAnimation(IExecutionContext<?, ?, ?> context);
+
 	/** if not null, the progress monitor used to report load progress */
 	void setProgressMonitor(IProgressMonitor progressMonitor);
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
@@ -22,13 +22,9 @@ public interface IRunConfiguration {
 	public static final String LAUNCH_DELAY = "GEMOC_ANIMATE_DELAY";
 	public static final String LAUNCH_SELECTED_LANGUAGE = "GEMOC_LAUNCH_SELECTED_LANGUAGE";
 	public static final String LAUNCH_MELANGE_QUERY = "GEMOC_LAUNCH_MELANGE_QUERY";
-	public static final String LAUNCH_MODEL_ENTRY_POINT = "LAUNCH_MODEL_ENTRY_POINT";
-	public static final String LAUNCH_METHOD_ENTRY_POINT = "LAUNCH_METHOD_ENTRY_POINT";
-	public static final String LAUNCH_INITIALIZATION_METHOD = "GEMOC_LAUNCH_INITIALIZATION_METHOD";
-	public static final String LAUNCH_INITIALIZATION_ARGUMENTS = "GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS";
 	public static final String LAUNCH_BREAK_START = "GEMOC_LAUNCH_BREAK_START";
 	public static final String DEBUG_MODEL_ID = "GEMOC_DEBUG_MODEL_ID";
-
+	
 	// parameters that should be derived from the language in future version
 	public static final String LAUNCH_DEADLOCK_DETECTION_DEPTH = "GEMOC_LAUNCH_DEADLOCK_DETECTION_DEPTH";
 
@@ -44,18 +40,8 @@ public interface IRunConfiguration {
 
 	int getAnimationDelay();
 	
-	int getDeadlockDetectionDepth();
-
 	Collection<EngineAddonSpecificationExtension> getEngineAddonExtensions();
 		
-	String getExecutionEntryPoint();
-	
-	String getModelEntryPoint();
-
-	String getModelInitializationMethod();
-	
-	String getModelInitializationArguments();
-	
 	String getDebugModelID();
 
 	boolean getBreakStart();

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/IEngineAddon.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/IEngineAddon.java
@@ -24,57 +24,57 @@ public interface IEngineAddon {
 	/**
 	 * Operation called before the engine starts
 	 */
-	default public void engineAboutToStart(IExecutionEngine engine) {
+	default public void engineAboutToStart(IExecutionEngine<?> engine) {
 	};
 
 	/**
 	 * Operation called after the engine have started
 	 */
-	default public void engineStarted(IExecutionEngine executionEngine) {
+	default public void engineStarted(IExecutionEngine<?> executionEngine) {
 	};
 
-	default public void engineInitialized(IExecutionEngine executionEngine) {
+	default public void engineInitialized(IExecutionEngine<?> executionEngine) {
 	};
 
-	default public void engineAboutToStop(IExecutionEngine engine) {
+	default public void engineAboutToStop(IExecutionEngine<?> engine) {
 	};
 
 	/**
 	 * Operation called after the engine has been stopped
 	 */
-	default public void engineStopped(IExecutionEngine engine) {
+	default public void engineStopped(IExecutionEngine<?> engine) {
 	};
 
 	/**
 	 * Operation before the engine has been disposed (and after the engine has
 	 * been stopped)
 	 */
-	default public void engineAboutToDispose(IExecutionEngine engine) {
+	default public void engineAboutToDispose(IExecutionEngine<?> engine) {
 	};
 
 	/**
 	 * Operation called before the Step has been chosen
 	 */
-	default public void aboutToSelectStep(IExecutionEngine engine, Collection<Step<?>> steps) {
+	default public void aboutToSelectStep(IExecutionEngine<?> engine, Collection<Step<?>> steps) {
 	};
 
-	default public void proposedStepsChanged(IExecutionEngine engine, Collection<Step<?>> steps) {
+	default public void proposedStepsChanged(IExecutionEngine<?> engine, Collection<Step<?>> steps) {
 	};
 
 	/**
 	 * Operation called after the Step has been chosen It also returns the
 	 * chosen Step
 	 */
-	default public void stepSelected(IExecutionEngine engine, Step<?> selectedStep) {
+	default public void stepSelected(IExecutionEngine<?> engine, Step<?> selectedStep) {
 	};
 
-	default public void aboutToExecuteStep(IExecutionEngine engine, Step<?> stepToExecute) {
+	default public void aboutToExecuteStep(IExecutionEngine<?> engine, Step<?> stepToExecute) {
 	};
 
-	default public void stepExecuted(IExecutionEngine engine, Step<?> stepExecuted) {
+	default public void stepExecuted(IExecutionEngine<?> engine, Step<?> stepExecuted) {
 	};
 
-	default public void engineStatusChanged(IExecutionEngine engine, RunStatus newStatus) {
+	default public void engineStatusChanged(IExecutionEngine<?> engine, RunStatus newStatus) {
 	};
 
 	/**

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/modelchangelistener/BatchModelChangeListener.xtend
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/modelchangelistener/BatchModelChangeListener.xtend
@@ -61,7 +61,7 @@ public class BatchModelChangeListener {
 		observedResources.addAll(resources)
 
 		observedResources.forEach [ r |
-			if (r != null) {
+			if (r !== null) {
 				r.eAdapters().add(adapter);
 			}
 		]
@@ -145,16 +145,16 @@ public class BatchModelChangeListener {
 
 							// Register potentially new or removed object
 							if ((feature as EReference).containment) {
-								if (previousValue != null && previousValue instanceof EObject)
+								if (previousValue !== null && previousValue instanceof EObject)
 									addToRemovedObjects(eventuallyRemoved, removedObjects, newObjects,
 										previousValue as EObject)
-								if (newValue != null && newValue instanceof EObject)
+								if (newValue !== null && newValue instanceof EObject)
 									addToNewObjects(eventuallyRemoved, removedObjects, newObjects, newValue as EObject)
 							}
 						}
 					} // Case data types: we compare values
-					else if (if (previousValue == null) {
-						newValue != null
+					else if (if (previousValue === null) {
+						newValue !== null
 					} else {
 						!previousValue.equals(newValue)
 					}) {
@@ -221,7 +221,7 @@ public class BatchModelChangeListener {
 	private static def void addToNewObjects(Collection<EObject> eventuallyRemoved, Collection<EObject> removedObjects,
 		Collection<EObject> newObjects, EObject object) {
 		eventuallyRemoved.remove(object)
-		if (object != null) {
+		if (object !== null) {
 			val hasMoved = removedObjects.remove(object)
 			if (!hasMoved) {
 				newObjects.add(object)
@@ -233,7 +233,7 @@ public class BatchModelChangeListener {
 	private static def void addToRemovedObjects(Collection<EObject> eventuallyRemoved,
 		Collection<EObject> removedObjects, Collection<EObject> newObjects, EObject object) {
 		eventuallyRemoved.add(object)
-		if (object != null) {
+		if (object !== null) {
 			val hasMoved = newObjects.remove(object)
 			if (!hasMoved)
 				removedObjects.add(object)
@@ -258,7 +258,7 @@ public class BatchModelChangeListener {
 	}
 
 	public def void cleanUp() {
-		for (r : observedResources.filter[r|r != null]) {
+		for (r : observedResources.filter[r|r !== null]) {
 			r.eAdapters().remove(adapter);
 		}
 	}

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/modelchangelistener/SimpleModelChangeListenerAddon.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/modelchangelistener/SimpleModelChangeListenerAddon.java
@@ -28,7 +28,7 @@ import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 public class SimpleModelChangeListenerAddon implements IEngineAddon, IModelChangeListenerAddon {
 
 	private EContentAdapter adapter;
-	private IExecutionEngine engine;
+	private IExecutionEngine<?> engine;
 	private Map<IEngineAddon, List<FieldChange>> changes;
 	private Set<IEngineAddon> registeredAddons;
 
@@ -39,7 +39,7 @@ public class SimpleModelChangeListenerAddon implements IEngineAddon, IModelChang
 				addon -> changes.get(addon).add(new FieldChange(feature, eObject, value, changeType)));
 	}
 
-	public SimpleModelChangeListenerAddon(final IExecutionEngine engine) {
+	public SimpleModelChangeListenerAddon(final IExecutionEngine<?> engine) {
 		this.engine = engine;
 		changes = new HashMap<>();
 		registeredAddons = new HashSet<>();
@@ -103,7 +103,7 @@ public class SimpleModelChangeListenerAddon implements IEngineAddon, IModelChang
 	}
 
 	@Override
-	public void engineAboutToStop(IExecutionEngine engine) {
+	public void engineAboutToStop(IExecutionEngine<?> engine) {
 		Set<Resource> allResources = org.eclipse.gemoc.commons.eclipse.emf.EMFResource.getRelatedResources(this.engine
 				.getExecutionContext().getResourceModel());
 		allResources.stream().forEach(r -> {

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/Extension.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/Extension.java
@@ -15,13 +15,11 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.gemoc.xdsmlframework.api.Activator;
 
-public class Extension 
-{
+public class Extension {
 
 	protected IConfigurationElement _configurationElement;
 
-	void setSpecification(IConfigurationElement configurationElement) 
-	{
+	void setSpecification(IConfigurationElement configurationElement) {
 		_configurationElement = configurationElement;
 	}
 
@@ -30,13 +28,11 @@ public class Extension
 	}
 
 	protected Object instanciate(String attributeName) throws CoreException {
-		try
-		{
+		try {
 			return _configurationElement.createExecutableExtension(attributeName);
-		}
-		catch(CoreException e)
-		{
-			String message = "Instanciation of one agent failed: " + e.getMessage() + " (see inner exception for more detail).";
+		} catch (CoreException e) {
+			String message = "Instanciation of one agent failed: " + e.getMessage()
+					+ " (see inner exception for more detail).";
 			CoreException exception = new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, message, e));
 			throw exception;
 		}
@@ -47,6 +43,5 @@ public class Extension
 		CoreException exception = new CoreException(new Status(Status.ERROR, Activator.PLUGIN_ID, message));
 		throw exception;
 	}
-
 
 }

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.sirius.editor.editorPlugin.SiriusEditorPlugin;
-import org.eclipse.sirius.editor.tools.internal.wizards.ViewpointSpecificationProjectWizard;
 import org.eclipse.sirius.ui.tools.api.project.ViewpointSpecificationProject;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/perspective/XDSMLPerspectiveFactory.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/perspective/XDSMLPerspectiveFactory.java
@@ -12,7 +12,6 @@ package org.eclipse.gemoc.xdsmlframework.ide.ui.perspective;
 
 import org.eclipse.debug.ui.IDebugUIConstants;
 import org.eclipse.jdt.ui.JavaUI;
-import org.eclipse.pde.internal.launching.IPDEConstants;
 import org.eclipse.pde.internal.ui.IPDEUIConstants;
 import org.eclipse.pde.internal.ui.views.target.TargetStateView;
 import org.eclipse.sirius.ui.tools.api.views.modelexplorerview.IModelExplorerView;

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
@@ -10,40 +10,32 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystem;
 import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
+import org.eclipse.gemoc.execution.sequential.javaengine.K3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
 import org.eclipse.gemoc.execution.sequential.javaengine.SequentialModelExecutionContext;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator;
 import org.eclipse.gemoc.executionframework.engine.commons.EngineContextException;
-import org.eclipse.gemoc.executionframework.engine.commons.ModelExecutionContext;
-import org.eclipse.gemoc.executionframework.engine.ui.commons.RunConfiguration;
 import org.eclipse.gemoc.executionframework.engine.ui.launcher.AbstractSequentialGemocLauncher;
 import org.eclipse.gemoc.executionframework.ui.views.engine.EnginesStatusView;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfigurationParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchconfigurationPackage;
 import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
-import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
-import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 
-public class Launcher extends AbstractSequentialGemocLauncher {
+public class Launcher extends AbstractSequentialGemocLauncher<SequentialModelExecutionContext<K3RunConfiguration>, K3RunConfiguration> {
 
 	public final static String TYPE_ID = Activator.PLUGIN_ID + ".launcher";
 
 	@Override
-	protected IExecutionEngine createExecutionEngine(RunConfiguration runConfiguration, ExecutionMode executionMode)
-			throws CoreException, EngineContextException {
+	protected PlainK3ExecutionEngine createExecutionEngine(K3RunConfiguration runConfiguration,
+			ExecutionMode executionMode) throws CoreException, EngineContextException {
 		// create and initialize engine
-		IExecutionEngine executionEngine = new PlainK3ExecutionEngine();
-		ModelExecutionContext executioncontext = new SequentialModelExecutionContext(runConfiguration, executionMode);
+		PlainK3ExecutionEngine executionEngine = new PlainK3ExecutionEngine();
+		SequentialModelExecutionContext<K3RunConfiguration> executioncontext = new SequentialModelExecutionContext<K3RunConfiguration>(
+				runConfiguration, executionMode);
 		executioncontext.getExecutionPlatform().getModelLoader().setProgressMonitor(this.launchProgressMonitor);
 		executioncontext.initializeResourceModel();
 		executionEngine.initialize(executioncontext);
@@ -76,8 +68,8 @@ public class Launcher extends AbstractSequentialGemocLauncher {
 	}
 
 	@Override
-	protected RunConfiguration parseLaunchConfiguration(ILaunchConfiguration configuration) throws CoreException {
-		return new RunConfiguration(configuration);
+	protected K3RunConfiguration parseLaunchConfiguration(ILaunchConfiguration configuration) throws CoreException {
+		return new K3RunConfiguration(configuration);
 	}
 
 	@Override
@@ -94,40 +86,4 @@ public class Launcher extends AbstractSequentialGemocLauncher {
 	protected void setDefaultsLaunchConfiguration(ILaunchConfigurationWorkingCopy configuration) {
 
 	}
-	
-	@Override
-	public Map<String, Object> parseLaunchConfiguration(LaunchConfiguration launchConfiguration) {
-		Map<String, Object> attributes = new HashMap<>();
-		for (LaunchConfigurationParameter param : launchConfiguration.getParameters()) {
-			switch (param.eClass().getClassifierID()) {
-				case LaunchconfigurationPackage.LANGUAGE_NAME_PARAMETER: {
-					attributes.put(IRunConfiguration.LAUNCH_SELECTED_LANGUAGE, param.getValue());
-				}
-				case LaunchconfigurationPackage.MODEL_URI_PARAMETER: {
-					attributes.put("Resource", param.getValue());
-				}
-				case LaunchconfigurationPackage.ANIMATOR_URI_PARAMETER: {
-					attributes.put("airdResource", param.getValue());
-				}
-				case LaunchconfigurationPackage.ENTRY_POINT_PARAMETER: {
-					attributes.put(IRunConfiguration.LAUNCH_METHOD_ENTRY_POINT, param.getValue());
-				}
-				case LaunchconfigurationPackage.MODEL_ROOT_PARAMETER: {
-					attributes.put(IRunConfiguration.LAUNCH_MODEL_ENTRY_POINT, param.getValue());
-				}
-				case LaunchconfigurationPackage.INITIALIZATION_METHOD_PARAMETER: {
-					attributes.put(IRunConfiguration.LAUNCH_INITIALIZATION_METHOD, param.getValue());
-				}
-				case LaunchconfigurationPackage.INITIALIZATION_ARGUMENTS_PARAMETER: {
-					attributes.put(IRunConfiguration.LAUNCH_INITIALIZATION_ARGUMENTS, param.getValue());
-				}
-				case LaunchconfigurationPackage.ADDON_EXTENSION_PARAMETER: {
-					attributes.put(param.getValue(), true);
-				}
-			}
-		}
-		return attributes;
-	}
-
-
 }

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/SequentialRunConfiguration.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/SequentialRunConfiguration.java
@@ -12,7 +12,7 @@ package org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.gemoc.executionframework.engine.ui.commons.RunConfiguration;
+import org.eclipse.gemoc.executionframework.engine.core.RunConfiguration;
 
 public class SequentialRunConfiguration extends RunConfiguration {
 

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
@@ -29,11 +29,12 @@ import org.eclipse.gemoc.commons.eclipse.emf.URIHelper;
 import org.eclipse.gemoc.commons.eclipse.ui.dialogs.SelectAnyIFileDialog;
 import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
 import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI;
+import org.eclipse.gemoc.execution.sequential.javaengine.K3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher.LauncherMessages;
+import org.eclipse.gemoc.executionframework.engine.commons.DslHelper;
 import org.eclipse.gemoc.executionframework.engine.commons.MelangeHelper;
-import org.eclipse.gemoc.executionframework.engine.ui.commons.RunConfiguration;
 import org.eclipse.gemoc.executionframework.ui.utils.ENamedElementQualifiedNameLabelProvider;
 import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectAIRDIFileDialog;
 import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectAnyEObjectDialog;
@@ -58,18 +59,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtext.naming.DefaultDeclarativeQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
-import org.eclipse.gemoc.commons.eclipse.emf.URIHelper;
-import org.eclipse.gemoc.commons.eclipse.ui.dialogs.SelectAnyIFileDialog;
-import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
-import org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator;
-import org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher.LauncherMessages;
-import org.eclipse.gemoc.executionframework.engine.commons.DslHelper;
-import org.eclipse.gemoc.executionframework.engine.commons.MelangeHelper;
-import org.eclipse.gemoc.executionframework.engine.ui.commons.RunConfiguration;
-import org.eclipse.gemoc.executionframework.ui.utils.ENamedElementQualifiedNameLabelProvider;
-import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectAIRDIFileDialog;
-import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectAnyEObjectDialog;
-import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectMainMethodDialog;
 import org.osgi.framework.Bundle;
 
 /**
@@ -132,16 +121,16 @@ public class LaunchConfigurationMainTab extends LaunchConfigurationTab {
 
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
-		configuration.setAttribute(RunConfiguration.LAUNCH_DELAY, 1000);
-		configuration.setAttribute(RunConfiguration.LAUNCH_MODEL_ENTRY_POINT, "");
-		configuration.setAttribute(RunConfiguration.LAUNCH_METHOD_ENTRY_POINT, "");
-		configuration.setAttribute(RunConfiguration.LAUNCH_SELECTED_LANGUAGE, "");
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_DELAY, 1000);
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_MODEL_ENTRY_POINT, "");
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_METHOD_ENTRY_POINT, "");
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_SELECTED_LANGUAGE, "");
 	}
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		try {
-			RunConfiguration runConfiguration = new RunConfiguration(
+			K3RunConfiguration runConfiguration = new K3RunConfiguration(
 					configuration);
 			_modelLocationText.setText(URIHelper
 					.removePlatformScheme(runConfiguration
@@ -182,24 +171,24 @@ public class LaunchConfigurationMainTab extends LaunchConfigurationTab {
 		configuration.setAttribute(
 				AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI,
 				this._siriusRepresentationLocationText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_DELAY,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_DELAY,
 				Integer.parseInt(_delayText.getText()));
-		configuration.setAttribute(RunConfiguration.LAUNCH_SELECTED_LANGUAGE,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_SELECTED_LANGUAGE,
 				_languageCombo.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_MELANGE_QUERY,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_MELANGE_QUERY,
 				_melangeQueryText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_MODEL_ENTRY_POINT,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_MODEL_ENTRY_POINT,
 				_entryPointModelElementText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_METHOD_ENTRY_POINT,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_METHOD_ENTRY_POINT,
 				_entryPointMethodText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_INITIALIZATION_METHOD,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_INITIALIZATION_METHOD,
 				_modelInitializationMethodText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_INITIALIZATION_ARGUMENTS,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_INITIALIZATION_ARGUMENTS,
 				_modelInitializationArgumentsText.getText());
-		configuration.setAttribute(RunConfiguration.LAUNCH_BREAK_START,
+		configuration.setAttribute(K3RunConfiguration.LAUNCH_BREAK_START,
 				_animationFirstBreak.getSelection());
 		// DebugModelID for sequential engine
-		configuration.setAttribute(RunConfiguration.DEBUG_MODEL_ID, Activator.DEBUG_MODEL_ID);
+		configuration.setAttribute(K3RunConfiguration.DEBUG_MODEL_ID, Activator.DEBUG_MODEL_ID);
 	}
 
 	@Override

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
@@ -11,7 +11,9 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.emf.transaction,
  fr.inria.diverse.melange.adapters,
  org.eclipse.gemoc.trace.commons.model;bundle-version="0.1.0",
- org.eclipse.gemoc.trace.commons;bundle-version="1.0.0"
+ org.eclipse.gemoc.trace.commons;bundle-version="1.0.0",
+ org.eclipse.debug.core,
+ org.eclipse.gemoc.trace.gemoc.api;bundle-version="3.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine
 Bundle-Activator: org.eclipse.gemoc.execution.sequential.javaengine.Activator

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/IK3RunConfiguration.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/IK3RunConfiguration.java
@@ -1,0 +1,19 @@
+package org.eclipse.gemoc.execution.sequential.javaengine;
+
+import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
+
+public interface IK3RunConfiguration extends IRunConfiguration {
+
+	public static final String LAUNCH_MODEL_ENTRY_POINT = "LAUNCH_MODEL_ENTRY_POINT";
+	public static final String LAUNCH_METHOD_ENTRY_POINT = "LAUNCH_METHOD_ENTRY_POINT";
+	public static final String LAUNCH_INITIALIZATION_METHOD = "GEMOC_LAUNCH_INITIALIZATION_METHOD";
+	public static final String LAUNCH_INITIALIZATION_ARGUMENTS = "GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS";
+
+	String getExecutionEntryPoint();
+
+	String getModelEntryPoint();
+
+	String getModelInitializationMethod();
+
+	String getModelInitializationArguments();
+}

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/K3RunConfiguration.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/K3RunConfiguration.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.execution.sequential.javaengine;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.gemoc.executionframework.engine.core.RunConfiguration;
+
+public class K3RunConfiguration extends RunConfiguration implements IK3RunConfiguration {
+
+	public K3RunConfiguration(ILaunchConfiguration launchConfiguration) throws CoreException {
+		super(launchConfiguration);
+		extractInformation();
+	}
+
+	protected void extractInformation() throws CoreException {
+		super.extractInformation();
+		_methodEntryPoint = getAttribute(LAUNCH_METHOD_ENTRY_POINT, "");
+		_modelEntryPoint = getAttribute(LAUNCH_MODEL_ENTRY_POINT, "");
+		_modelInitializationMethod = getAttribute(LAUNCH_INITIALIZATION_METHOD, "");
+		_modelInitializationArguments = getAttribute(LAUNCH_INITIALIZATION_ARGUMENTS, "");
+	}
+
+	private String _methodEntryPoint;
+	private String _modelEntryPoint;
+	private String _modelInitializationMethod;
+	private String _modelInitializationArguments;
+
+	@Override
+	public String getExecutionEntryPoint() {
+		return _methodEntryPoint;
+	}
+
+	@Override
+	public String getModelEntryPoint() {
+		return _modelEntryPoint;
+	}
+
+	@Override
+	public String getModelInitializationMethod() {
+		return _modelInitializationMethod;
+	}
+
+	@Override
+	public String getModelInitializationArguments() {
+		return _modelInitializationArguments;
+	}
+
+}

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/K3RunConfiguration.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/K3RunConfiguration.java
@@ -18,7 +18,6 @@ public class K3RunConfiguration extends RunConfiguration implements IK3RunConfig
 
 	public K3RunConfiguration(ILaunchConfiguration launchConfiguration) throws CoreException {
 		super(launchConfiguration);
-		extractInformation();
 	}
 
 	protected void extractInformation() throws CoreException {

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -29,18 +29,6 @@ import org.eclipse.emf.transaction.impl.InternalTransactionalEditingDomain;
 import org.eclipse.gemoc.executionframework.engine.commons.MelangeHelper;
 import org.eclipse.gemoc.executionframework.engine.core.AbstractCommandBasedSequentialExecutionEngine;
 import org.eclipse.gemoc.executionframework.engine.core.EngineStoppedException;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.AddonExtensionParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.AnimatorURIParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.EntryPointParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.InitializationArgumentsParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.InitializationMethodParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LanguageNameParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchConfiguration;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchconfigurationFactory;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.ModelRootParameter;
-import org.eclipse.gemoc.trace.commons.model.launchconfiguration.ModelURIParameter;
-import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext;
-import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
@@ -58,20 +46,20 @@ import fr.inria.diverse.k3.al.annotationprocessor.stepmanager.StepManagerRegistr
 import fr.inria.diverse.melange.adapters.EObjectAdapter;
 
 /**
- * Implementation of the GEMOC Execution engine dedicated to run Kermeta 3 operational semantic
+ * Implementation of the GEMOC Execution engine dedicated to run Kermeta 3
+ * operational semantic
  * 
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
-public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine implements IStepManager {
+public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine<SequentialModelExecutionContext<K3RunConfiguration>, K3RunConfiguration>
+		implements IStepManager {
 
 	private Method initializeMethod;
 	private List<Object> initializeMethodParameters;
 	private Method entryPointMethod;
 	private List<Object> entryPointMethodParameters;
 	private Class<?> entryPointClass;
-
-	private static final String LAUNCH_CONFIGURATION_TYPE = "org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher";
 
 	@Override
 	public String engineKindName() {
@@ -80,13 +68,13 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 
 	/**
 	 * Constructs a PlainK3 execution engine using an entry point (~ a main
-	 * operation) The entrypoint will register itself as a StepManager into the
-	 * K3 step manager registry, and unregister itself at the end. As a
-	 * StepManager, the PlainK3ExecutionEngine will receive callbacks through
-	 * its "executeStep" operation.
+	 * operation) The entrypoint will register itself as a StepManager into the K3
+	 * step manager registry, and unregister itself at the end. As a StepManager,
+	 * the PlainK3ExecutionEngine will receive callbacks through its "executeStep"
+	 * operation.
 	 */
 	@Override
-	protected void prepareEntryPoint(IExecutionContext executionContext) {
+	protected void prepareEntryPoint(SequentialModelExecutionContext<K3RunConfiguration> executionContext) {
 		/*
 		 * Get info from the RunConfiguration
 		 */
@@ -140,7 +128,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	}
 
 	@Override
-	protected void prepareInitializeModel(IExecutionContext executionContext) {
+	protected void prepareInitializeModel(SequentialModelExecutionContext<K3RunConfiguration> executionContext) {
 
 		// try to get the initializeModelRunnable
 		String modelInitializationMethodQName = executionContext.getRunConfiguration().getModelInitializationMethod();
@@ -244,8 +232,9 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 		if (initializeMethod != null) {
 			StepManagerRegistry.getInstance().registerManager(PlainK3ExecutionEngine.this);
 			try {
-				final boolean isStepMethod =	initializeMethod.isAnnotationPresent(fr.inria.diverse.k3.al.annotationprocessor.Step.class);
-				if(!isStepMethod){
+				final boolean isStepMethod = initializeMethod
+						.isAnnotationPresent(fr.inria.diverse.k3.al.annotationprocessor.Step.class);
+				if (!isStepMethod) {
 					fr.inria.diverse.k3.al.annotationprocessor.stepmanager.StepCommand command = new fr.inria.diverse.k3.al.annotationprocessor.stepmanager.StepCommand() {
 						@Override
 						public void execute() {
@@ -253,7 +242,8 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 						}
 					};
 					fr.inria.diverse.k3.al.annotationprocessor.stepmanager.IStepManager stepManager = PlainK3ExecutionEngine.this;
-					stepManager.executeStep(entryPointMethodParameters.get(0), command, entryPointClass.getName(), initializeMethod.getName());
+					stepManager.executeStep(entryPointMethodParameters.get(0), command, entryPointClass.getName(),
+							initializeMethod.getName());
 				} else {
 					callInitializeModel();
 				}
@@ -288,8 +278,8 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 
 	@Override
 	/*
-	 * This is the operation called from K3 code. We use this callback to pass
-	 * the command to the generic executeOperation operation. (non-Javadoc)
+	 * This is the operation called from K3 code. We use this callback to pass the
+	 * command to the generic executeOperation operation. (non-Javadoc)
 	 * 
 	 * @see fr.inria.diverse.k3.al.annotationprocessor.stepmanager.IStepManager#
 	 * executeStep(java.lang.Object,
@@ -307,8 +297,8 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 
 	@Override
 	/*
-	 * This is the operation used to act as a StepManager in K3. We return true
-	 * if we have the same editing domain as the object. (non-Javadoc)
+	 * This is the operation used to act as a StepManager in K3. We return true if
+	 * we have the same editing domain as the object. (non-Javadoc)
 	 * 
 	 * @see fr.inria.diverse.k3.al.annotationprocessor.stepmanager.IStepManager#
 	 * canHandle (java.lang.Object)
@@ -328,7 +318,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * 
 	 * Return null if not found.
 	 */
-	private Bundle findBundle(final IExecutionContext executionContext, String aspectClassName) {
+	private Bundle findBundle(final SequentialModelExecutionContext<K3RunConfiguration> executionContext, String aspectClassName) {
 
 		// Look using JavaWorkspaceScope as this is safer and will look in
 		// dependencies
@@ -357,11 +347,10 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 
 	/**
 	 * search the bundle that contains the Main class. The search is done in the
-	 * workspace scope (ie. if it is defined in the current workspace it will
-	 * find it
+	 * workspace scope (ie. if it is defined in the current workspace it will find
+	 * it
 	 * 
-	 * @return the name of the bundle containing the Main class or null if not
-	 *         found
+	 * @return the name of the bundle containing the Main class or null if not found
 	 */
 	private IType getITypeMainByWorkspaceScope(String className) {
 		SearchPattern pattern = SearchPattern.createPattern(className, IJavaSearchConstants.CLASS,
@@ -404,7 +393,9 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 
 	/**
 	 * Load the model for the given URI
-	 * @param modelURI to load
+	 * 
+	 * @param modelURI
+	 *            to load
 	 * @return the loaded resource
 	 */
 	public static Resource loadModel(URI modelURI) {
@@ -418,60 +409,5 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 			// chut
 		}
 		return resource;
-	}
-
-	@Override
-	public LaunchConfiguration extractLaunchConfiguration() {
-		final IRunConfiguration configuration = getExecutionContext().getRunConfiguration();
-		final LaunchConfiguration launchConfiguration = LaunchconfigurationFactory.eINSTANCE
-				.createLaunchConfiguration();
-		launchConfiguration.setType(LAUNCH_CONFIGURATION_TYPE);
-		if (configuration.getLanguageName() != "") {
-			final LanguageNameParameter languageNameParam = LaunchconfigurationFactory.eINSTANCE.createLanguageNameParameter();
-			languageNameParam.setValue(configuration.getLanguageName());
-			launchConfiguration.getParameters().add(languageNameParam);
-		}
-		final URI modelURI = configuration.getExecutedModelURI();
-		if (modelURI != null) {
-			final String scheme = modelURI.scheme() + ":/resource";
-			final ModelURIParameter modelURIParam = LaunchconfigurationFactory.eINSTANCE.createModelURIParameter();
-			modelURIParam.setValue(modelURI.toString().substring(scheme.length()));
-			launchConfiguration.getParameters().add(modelURIParam);
-		}
-		final URI animatorURI = configuration.getAnimatorURI();
-		if (configuration.getAnimatorURI() != null) {
-			final String scheme = animatorURI.scheme() + ":/resource";
-			final AnimatorURIParameter animatorURIParam = LaunchconfigurationFactory.eINSTANCE.createAnimatorURIParameter();
-			animatorURIParam.setValue(animatorURI.toString().substring(scheme.length()));
-			launchConfiguration.getParameters().add(animatorURIParam);
-		}
-		if (configuration.getExecutionEntryPoint() != null) {
-			final EntryPointParameter entryPointParam = LaunchconfigurationFactory.eINSTANCE.createEntryPointParameter();
-			entryPointParam.setValue(configuration.getExecutionEntryPoint());
-			launchConfiguration.getParameters().add(entryPointParam);
-		}
-		if (configuration.getModelEntryPoint() != null) {
-			final ModelRootParameter modelRootParam = LaunchconfigurationFactory.eINSTANCE.createModelRootParameter();
-			modelRootParam.setValue(configuration.getModelEntryPoint());
-			launchConfiguration.getParameters().add(modelRootParam);
-		}
-		if (configuration.getModelInitializationMethod() != null) {
-			final InitializationMethodParameter initializationMethodParam = LaunchconfigurationFactory.eINSTANCE
-					.createInitializationMethodParameter();
-			initializationMethodParam.setValue(configuration.getModelInitializationMethod());
-			launchConfiguration.getParameters().add(initializationMethodParam);
-		}
-		if (configuration.getModelInitializationArguments() != null) {
-			final InitializationArgumentsParameter initializationArgumentsParam = LaunchconfigurationFactory.eINSTANCE
-					.createInitializationArgumentsParameter();
-			initializationArgumentsParam.setValue(configuration.getModelInitializationArguments());
-			launchConfiguration.getParameters().add(initializationArgumentsParam);
-		}
-		configuration.getEngineAddonExtensions().forEach(extensionPoint -> {
-			final AddonExtensionParameter addonExtensionParam = LaunchconfigurationFactory.eINSTANCE.createAddonExtensionParameter();
-			addonExtensionParam.setValue(extensionPoint.getName());
-			launchConfiguration.getParameters().add(addonExtensionParam);
-		});
-		return launchConfiguration;
 	}
 }

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/SequentialModelExecutionContext.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/SequentialModelExecutionContext.java
@@ -10,36 +10,30 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.sequential.javaengine;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.gemoc.execution.sequential.javaxdsml.api.extensions.languages.SequentialLanguageDefinitionExtension;
 import org.eclipse.gemoc.execution.sequential.javaxdsml.api.extensions.languages.SequentialLanguageDefinitionExtensionPoint;
+import org.eclipse.gemoc.executionframework.engine.commons.DefaultExecutionPlatform;
 import org.eclipse.gemoc.executionframework.engine.commons.EngineContextException;
-import org.eclipse.gemoc.executionframework.engine.commons.ModelExecutionContext;
+import org.eclipse.gemoc.executionframework.engine.commons.AbstractModelExecutionContext;
+import org.eclipse.gemoc.trace.commons.model.trace.MSEModel;
 import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
-import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtension;
 
-import org.eclipse.gemoc.trace.commons.model.trace.MSEModel;
+public class SequentialModelExecutionContext<T extends IRunConfiguration> extends AbstractModelExecutionContext<T, DefaultExecutionPlatform, SequentialLanguageDefinitionExtension> {
 
-public class SequentialModelExecutionContext extends ModelExecutionContext 
-{
-
-	
-	public SequentialModelExecutionContext(IRunConfiguration runConfiguration, ExecutionMode executionMode)
-			throws EngineContextException
-	{
+	public SequentialModelExecutionContext(T runConfiguration, ExecutionMode executionMode)
+			throws EngineContextException {
 		super(runConfiguration, executionMode);
-		
 	}
-	
+
 	@Override
-	protected LanguageDefinitionExtension getLanguageDefinition(String languageName) throws EngineContextException
-	{
+	protected SequentialLanguageDefinitionExtension getLanguageDefinition(String languageName) throws EngineContextException {
 		SequentialLanguageDefinitionExtension languageDefinition = SequentialLanguageDefinitionExtensionPoint
 				.findDefinition(_runConfiguration.getLanguageName());
-		if (languageDefinition == null)
-		{
-			String message = "Cannot find sequential xdsml definition for the language " + _runConfiguration.getLanguageName()
-					+ ", please verify that is is correctly deployed.";
+		if (languageDefinition == null) {
+			String message = "Cannot find sequential xdsml definition for the language "
+					+ _runConfiguration.getLanguageName() + ", please verify that is is correctly deployed.";
 			EngineContextException exception = new EngineContextException(message);
 			throw exception;
 		}
@@ -48,9 +42,12 @@ public class SequentialModelExecutionContext extends ModelExecutionContext
 
 	@Override
 	public MSEModel getMSEModel() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
-	
+	@Override
+	protected DefaultExecutionPlatform createExecutionPlatform() throws CoreException {
+		return new DefaultExecutionPlatform(_languageDefinition, _runConfiguration);
+	}
+
 }

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDSAProjectHandler.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDSAProjectHandler.java
@@ -11,7 +11,7 @@
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -85,7 +85,7 @@ public class CreateDSAProjectHandler extends AbstractDslSelectHandler implements
 			dsl.getEntries().add(k3Entry);
 		}
 		try {
-			res.save(new HashMap());
+			res.save(Collections.emptyMap());
 		} catch (IOException e) {
 			Activator.error(e.getMessage(), e);
 		}

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDomainModelProjectHandler.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDomainModelProjectHandler.java
@@ -11,7 +11,7 @@
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionEvent;
@@ -74,7 +74,7 @@ public class CreateDomainModelProjectHandler extends AbstractDslSelectHandler im
 			dsl.getEntries().add(ecoreEntry);
 		}
 		try {
-			res.save(new HashMap());
+			res.save(Collections.emptyMap());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateSiriusEditorProjectHandler.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateSiriusEditorProjectHandler.java
@@ -11,7 +11,7 @@
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionEvent;
@@ -78,7 +78,7 @@ public class CreateSiriusEditorProjectHandler extends AbstractDslSelectHandler i
 			dsl.getEntries().add(siriusEntry);
 		}
 		try {
-			res.save(new HashMap());
+			res.save(Collections.emptyMap());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateXtextEditorProjectHandler.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateXtextEditorProjectHandler.java
@@ -11,7 +11,7 @@
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionEvent;
@@ -79,7 +79,7 @@ public class CreateXtextEditorProjectHandler extends AbstractDslSelectHandler im
 			dsl.getEntries().add(xtextEntry);
 		}
 		try {
-			res.save(new HashMap());
+			res.save(Collections.emptyMap());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/menu/AddDSA.xtend
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/menu/AddDSA.xtend
@@ -10,13 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.menu
 
-import java.util.List
-import java.util.Set
-import org.eclipse.core.commands.ExecutionEvent
-import org.eclipse.emf.ecore.EStructuralFeature
-import org.eclipse.xtext.nodemodel.INode
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils
-import org.eclipse.xtext.ui.editor.utils.EditorUtils
 import org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands.CreateDSAProjectHandler
 
 class AddDSA extends CreateDSAProjectHandler {

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/MelangeSequentialSingleLanguageNewWizard.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/MelangeSequentialSingleLanguageNewWizard.java
@@ -10,12 +10,9 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates;
 
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.BaseProjectWizardFields;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.templates.ITemplateSection;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.templates.NewProjectTemplateWizard;
-import org.eclipse.pde.internal.ui.PDEPlugin;
 import org.eclipse.xtext.util.Strings;
 
 public class MelangeSequentialSingleLanguageNewWizard extends NewProjectTemplateWizard{

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/MelangeSequentialSingleLanguageTemplate.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/MelangeSequentialSingleLanguageTemplate.java
@@ -39,7 +39,6 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtext.util.Strings;

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/services/AbstractDSLDebuggerServices.java
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/src/org/eclipse/gemoc/dsl/debug/ide/sirius/ui/services/AbstractDSLDebuggerServices.java
@@ -10,14 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.dsl.debug.ide.sirius.ui.services;
 
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
-import org.eclipse.gemoc.trace.commons.model.trace.ParallelStep;
-import org.eclipse.gemoc.trace.commons.model.trace.Step;
-import org.eclipse.gemoc.dsl.debug.StackFrame;
-import org.eclipse.gemoc.dsl.debug.ide.DSLBreakpoint;
-import org.eclipse.gemoc.dsl.debug.ide.adapter.IDSLCurrentInstructionListener;
-import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.DebugSiriusIdeUiPlugin;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +34,13 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.ExceptionHandler;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.impl.AbstractTransactionalCommandStack;
+import org.eclipse.gemoc.dsl.debug.StackFrame;
+import org.eclipse.gemoc.dsl.debug.ide.DSLBreakpoint;
+import org.eclipse.gemoc.dsl.debug.ide.adapter.IDSLCurrentInstructionListener;
+import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.DebugSiriusIdeUiPlugin;
+import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
+import org.eclipse.gemoc.trace.commons.model.trace.ParallelStep;
+import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.sirius.business.api.dialect.DialectManager;
 import org.eclipse.sirius.business.api.dialect.command.RefreshRepresentationsCommand;
 import org.eclipse.sirius.diagram.DDiagram;
@@ -446,14 +445,14 @@ public abstract class AbstractDSLDebuggerServices {
 			if (currentInstruction instanceof ParallelStep) {
 				addMseOccurenceAndCallerToInstructionsURIs(instructionURIs,
 						((ParallelStep<?, ?>)currentInstruction).getMseoccurrence());
-				for (Step step : ((ParallelStep<?, ?>)currentInstruction).getSubSteps()) {
+				for (Step<?> step : ((ParallelStep<?, ?>)currentInstruction).getSubSteps()) {
 					addMseOccurenceAndCallerToInstructionsURIs(instructionURIs, step.getMseoccurrence());
 				}
 			} else if (currentInstruction instanceof Step) {
 				if (!(currentInstruction.eContainer() instanceof ParallelStep)) {
 					// do not show internal step of parallel step, because they are already shown as a
 					// parallel
-					addMseOccurenceAndCallerToInstructionsURIs(instructionURIs, ((Step)currentInstruction)
+					addMseOccurenceAndCallerToInstructionsURIs(instructionURIs, ((Step<?>)currentInstruction)
 							.getMseoccurrence());
 				}
 			} else {

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons/src/org/eclipse/gemoc/trace/commons/EcoreCraftingUtil.xtend
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons/src/org/eclipse/gemoc/trace/commons/EcoreCraftingUtil.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
@@ -33,7 +33,7 @@ class EcoreCraftingUtil {
 	}
 
 	public static def EReference addReferenceToClass(EClass clazz, String refName, EClass refType) {
-		if (clazz != null && refName != null && refName != "" && refType != null) {
+		if (clazz !== null && refName !== null && refName != "" && refType !== null) {
 			val res = EcoreFactory.eINSTANCE.createEReference
 			res.name = refName
 			res.EType = refType
@@ -42,7 +42,6 @@ class EcoreCraftingUtil {
 		} else {
 			return null
 		}
-
 	}
 
 	public static def String getBaseFQN(EOperation o) {
@@ -72,7 +71,7 @@ class EcoreCraftingUtil {
 
 	public static def String getFQN(EClassifier c, String separator) {
 		val EPackage p = c.getEPackage
-		if (p != null) {
+		if (p !== null) {
 			return getEPackageFQN(p, separator) + separator + c.name
 		} else {
 			return c.name
@@ -81,7 +80,7 @@ class EcoreCraftingUtil {
 
 	public static def String getEPackageFQN(EPackage p, String separator) {
 		val EPackage superP = p.getESuperPackage
-		if (superP != null) {
+		if (superP !== null) {
 			return getEPackageFQN(superP, separator) + separator + p.name
 		} else {
 			return p.name
@@ -89,9 +88,9 @@ class EcoreCraftingUtil {
 	}
 
 	public static def String getBaseFQN(EClassifier c) {
-		if (c != null) {
+		if (c !== null) {
 			val EPackage p = c.getEPackage
-			if (p != null) {
+			if (p !== null) {
 				return getBaseFQN(p) + "." + c.name
 			} else {
 				return c.name
@@ -108,7 +107,7 @@ class EcoreCraftingUtil {
 	public static def String getJavaFQN(EClassifier c, Set<GenPackage> refGenPackages,
 		boolean enforcePrimitiveJavaClasses) {
 
-		if (c.instanceClass != null) {
+		if (c.instanceClass !== null) {
 			if (enforcePrimitiveJavaClasses) {
 				switch (c.instanceClass.canonicalName) {
 					case "int": return "java.lang.Integer"
@@ -120,13 +119,13 @@ class EcoreCraftingUtil {
 
 		}
 
-		if (c.instanceClassName != null && c.instanceClassName != "")
+		if (c.instanceClassName !== null && c.instanceClassName != "")
 			return c.instanceClassName
 
 		var String base = ""
 		val gc = getGenClassifier(c, refGenPackages)
 
-		if (gc != null && gc.genPackage != null) {
+		if (gc !== null && gc.genPackage !== null) {
 			base = getBase(gc.genPackage)
 		}
 		return base + getBaseFQN(c);
@@ -134,7 +133,7 @@ class EcoreCraftingUtil {
 
 	private static def String getBase(GenPackage gp) {
 		var String base = ""
-		if (gp.basePackage != null && gp.superGenPackage == null) {
+		if (gp.basePackage !== null && gp.superGenPackage === null) {
 			base = gp.basePackage + "."
 		}
 		return base
@@ -142,7 +141,7 @@ class EcoreCraftingUtil {
 
 	public static def String getBaseFQN(EPackage p) {
 		val EPackage superP = p.getESuperPackage
-		if (superP != null) {
+		if (superP !== null) {
 			return getBaseFQN(superP) + "." + p.name
 		} else {
 			return p.name
@@ -153,21 +152,21 @@ class EcoreCraftingUtil {
 
 		var String base = ""
 		val gp = getGenPackage(p, refGenPackages)
-		if (gp != null) {
+		if (gp !== null) {
 			base = getBase(gp)
 		}
 		return base + getBaseFQN(p);
 	}
 
 	public static def GenClassifier getGenClassifier(EClassifier c, Set<GenPackage> refGenPackages) {
-		if (c != null) {
+		if (c !== null) {
 			for (gp : refGenPackages) {
 				for (gc : gp.eAllContents.filter(GenClassifier).toSet) {
 					val ecoreClass = gc.ecoreClassifier
-					if (ecoreClass != null) {
+					if (ecoreClass !== null) {
 						val s1 = getBaseFQN(ecoreClass)
 						val s2 = getBaseFQN(c)
-						if (s1 != null && s2 != null && s1.equalsIgnoreCase(s2)) {
+						if (s1 !== null && s2 !== null && s1.equalsIgnoreCase(s2)) {
 							return gc
 						}
 					}
@@ -179,13 +178,13 @@ class EcoreCraftingUtil {
 	}
 
 	public static def GenPackage getGenPackage(EPackage p, Set<GenPackage> refGenPackages) {
-		if (p != null) {
+		if (p !== null) {
 			for (gp : refGenPackages) {
 				val packageInGenpackage = gp.getEcorePackage
-				if (packageInGenpackage != null) {
+				if (packageInGenpackage !== null) {
 					val s1 = getBaseFQN(p)
 					val s2 = getBaseFQN(packageInGenpackage)
-					if (s1 != null && s2 != null && s1.equalsIgnoreCase(s2)) {
+					if (s1 !== null && s2 !== null && s1.equalsIgnoreCase(s2)) {
 						return gp
 					}
 				}

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
@@ -47,7 +47,7 @@ import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonS
 
 abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTraceAddon<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> {
 
-	private IExecutionContext _executionContext
+	private IExecutionContext<?, ?, ?> _executionContext
 	private ITraceExplorer<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExplorer
 	private ITraceExtractor<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExtractor
 	private ITraceConstructor traceConstructor
@@ -93,23 +93,23 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 
 	private static def String getEPackageFQN(EPackage p, String separator) {
 		val EPackage superP = p.getESuperPackage
-		if (superP != null) {
+		if (superP !== null) {
 			return getEPackageFQN(superP, separator) + separator + p.name
 		} else {
 			return p.name.toFirstUpper
 		}
 	}
 
-	override aboutToExecuteStep(IExecutionEngine executionEngine, Step<?> step) {
+	override aboutToExecuteStep(IExecutionEngine<?> executionEngine, Step<?> step) {
 		manageStep(step, true)
 	}
 
-	override stepExecuted(IExecutionEngine engine, Step<?> step) {
+	override stepExecuted(IExecutionEngine<?> engine, Step<?> step) {
 		manageStep(step, false)
 	}
 
 	private def manageStep(Step<?> step, boolean add) {
-		if (step != null) {
+		if (step !== null) {
 			modifyTrace([
 				traceConstructor.addState(listenerAddon.getChanges(this))
 				if (add) {
@@ -135,8 +135,8 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 	/**
 	 * To construct the trace manager
 	 */
-	override engineAboutToStart(IExecutionEngine engine) {
-		if (_executionContext == null) {
+	override engineAboutToStart(IExecutionEngine<?> engine) {
+		if (_executionContext === null) {
 			_executionContext = engine.executionContext
 
 			val modelResource = _executionContext.resourceModel
@@ -147,7 +147,7 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 
 			// We check whether or not we need transactions
 			val ed = TransactionUtil.getEditingDomain(rs)
-			needTransaction = ed != null
+			needTransaction = ed !== null
 
 			val URI traceModelURI = URI.createPlatformResourceURI(
 				_executionContext.getWorkspace().getExecutionPath().toString() + "/execution.trace", false)

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/views/StateGraphViewPart.java
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/src/org/eclipse/gemoc/addon/stategraph/views/StateGraphViewPart.java
@@ -77,18 +77,18 @@ public class StateGraphViewPart extends EngineSelectionDependentViewPart {
 	}
 
 	@Override
-	public void engineSelectionChanged(IExecutionEngine engine) {
+	public void engineSelectionChanged(IExecutionEngine<?> engine) {
 		if (engine != null) {
-			Set<IMultiDimensionalTraceAddon> traceAddons = engine.getAddonsTypedBy(IMultiDimensionalTraceAddon.class);
-			if (!traceAddons.isEmpty()) {
-				final IMultiDimensionalTraceAddon<Step<?>, State<?,?>, TracedObject<?>, Dimension<?>, Value<?>> traceAddon = traceAddons.iterator().next();
+			engine.getAddonsTypedBy(IMultiDimensionalTraceAddon.class).stream().findFirst().ifPresent(addon -> {
+				@SuppressWarnings("unchecked")
+				final IMultiDimensionalTraceAddon<Step<?>, State<?,?>, TracedObject<?>, Dimension<?>, Value<?>> traceAddon = addon;
 				stateGraph = new StateGraph();
 				stateGraph.setTraceExtractor(traceAddon.getTraceExtractor());
 				stateGraph.setTraceExplorer(traceAddon.getTraceExplorer());
 				traceAddon.getTraceNotifier().addListener(stateGraph);
 				renderer.setStateGraph(stateGraph);
 				stateGraph.update();
-			}
+			});
 		}
 	}
 
@@ -150,7 +150,7 @@ public class StateGraphViewPart extends EngineSelectionDependentViewPart {
 			}
 
 			@Override
-			public void engineSelectionChanged(IExecutionEngine engine) {
+			public void engineSelectionChanged(IExecutionEngine<?> engine) {
 			}
 
 			@Override
@@ -172,7 +172,7 @@ public class StateGraphViewPart extends EngineSelectionDependentViewPart {
 			}
 
 			@Override
-			public void engineSelectionChanged(IExecutionEngine engine) {
+			public void engineSelectionChanged(IExecutionEngine<?> engine) {
 			}
 
 			@Override
@@ -199,7 +199,7 @@ public class StateGraphViewPart extends EngineSelectionDependentViewPart {
 			}
 
 			@Override
-			public void engineSelectionChanged(IExecutionEngine engine) {
+			public void engineSelectionChanged(IExecutionEngine<?> engine) {
 			}
 
 			@Override


### PR DESCRIPTION
IRunConfiguration:
- removed K3- and Concurrency-specific concepts from IRunConfiguration
and RunConfiguration
- created a K3RunConfiguration extending RunConfiguration and
implementing IK3RunConfiguration (also new) which adds K3-specific
concepts
- moved RunConfiguration from
org.eclipse.gemoc.executionframework.engine.ui to
org.eclipse.gemoc.executionframework.engine

IExecutionContext:
- added IRunconfiguration, IExecutionPlatform and
LanguageDefinitionExtension type parameters to IExecutionContext
- renamed ModelExecutionContext to AbstractModelExecutionContext for
clarity
- added IRunConfiguration type parameter to
SequentialModelExecutionContext

IExecutionEngine:
- added IExecutionContext and IRunConfiguration type parameters to
IExecutionEngine
- PlainK3ExecutionEngine now sets the IExecutionEngine type parameter
to K3RunConfiguration

Other:
- added IExecutionContext to AbstractGemocLauncher
- cleaned up several warnings on the way

As a result, one can now introduce IRunConfiguration,
IExecutionPlatform, LanguageDefinitionExtension and IExecutionContext
subtypes to fit various needs such as new launch configuration
parameters.