### PR TITLE
fix cached values not being properly cleaned

### DIFF
--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceExplorer.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceExplorer.java
@@ -241,6 +241,9 @@ public class GenericTraceExplorer implements ITraceExplorer<Step<?>, State<?,?>,
 
 		callStack.clear();
 		callStack.addAll(stepPath);
+
+		canBackValueCache.clear();
+		canStepValueCache.clear();
 	}
 	
 	private void goTo(State<?,?> state) {


### PR DESCRIPTION
Initial boolean values controlling whether to enable left and right arrows on the timeline dimensions were kept in cache forever, leading to arrows keep their initial disabled state.