### PR TITLE
Display step arguments in the debugger stack view

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebugger.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/AbstractGemocDebugger.java
@@ -38,7 +38,6 @@ import org.eclipse.gemoc.dsl.debug.StackFrame;
 import org.eclipse.gemoc.dsl.debug.ide.AbstractDSLDebugger;
 import org.eclipse.gemoc.dsl.debug.ide.adapter.DSLStackFrameAdapter;
 import org.eclipse.gemoc.dsl.debug.ide.event.IDSLDebugEventProcessor;
-import org.eclipse.gemoc.trace.commons.model.trace.MSEOccurrence;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.FieldChange;


### PR DESCRIPTION
Currently, the execution framework does not do anything with the arguments that may be present in a `Step` object (ie. the elements passed as args to the method call of the corresponding execution rule).

This PR makes the engine and the debugger aware of such arguments, and adapts accordingly the stack view as follows:

![capture d ecran de 2018-06-25 14-45-21](https://user-images.githubusercontent.com/5868014/41850874-6eba0e94-7886-11e8-9c74-eec80037056e.png)

*(note: at the moment K3 does not send arguments to the K3 engine, which means K3 must be changed first to take advantage of this cross-engine change)*

