### PR TITLE
Bump components and studio versions

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.executionframework.debugger.ui
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.debugger.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.gemoc.executionframework.debugger.ui.Activator
 Export-Package: org.eclipse.gemoc.executionframework.debugger.ui;uses:="org.eclipse.gemoc.xdsmlframework.api.core,org.eclipse.core.commands,org.eclipse.jface.viewers",

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger.ui/pom.xml
@@ -18,11 +18,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.debugger.ui</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.executionframework.debugger
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.debugger;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.gemoc.executionframework.debugger.Activator
 Require-Bundle: com.google.guava,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/pom.xml
@@ -18,11 +18,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.debugger</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Execution Engine UI
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.engine.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.executionframework.engine.ui.Activator
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/pom.xml
@@ -7,11 +7,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.engine.ui</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 <!--   <build> -->
 <!-- 	  <plugins> -->

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Engine
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.engine;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.executionframework.engine.Activator
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/pom.xml
@@ -7,11 +7,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.engine</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 <!--   <build> -->
 <!-- 	  <plugins> -->

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.event.manager;singleton:=true
 Export-Package: org.eclipse.gemoc.executionframework.event.manager
 Bundle-Name: org.eclipse.gemoc.executionframework.event.manager
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Require-Bundle: fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="3.0.0";visibility:=reexport,
  org.eclipse.xtend.lib;bundle-version="2.6.0";visibility:=private,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/pom.xml
@@ -18,11 +18,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.event.manager</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.event.model.edit;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.gemoc.executionframework.event.model.event.provider.EventEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.edit/pom.xml
@@ -18,10 +18,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.event.model.edit</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.event.model.editor;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.gemoc.executionframework.event.model.event.presentation.EventEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model.editor/pom.xml
@@ -18,10 +18,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.event.model.editor</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.event.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.model/pom.xml
@@ -18,10 +18,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.event.model</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eventmanager
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.event.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.executionframework.event.ui.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.ui/pom.xml
@@ -18,10 +18,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.event.ui</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Sirius
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.extensions.sirius;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.executionframework.extensions.sirius.Activator
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.sirius.diagram.ui;bundle-version="4.0.0",

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/pom.xml
@@ -18,11 +18,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.extensions.sirius</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 <!--   <build> -->
 <!-- 	  <plugins> -->

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Execution framework UI
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.executionframework.ui.Activator
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/pom.xml
@@ -18,11 +18,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   	<artifactId>org.eclipse.gemoc.executionframework.ui</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
   	<packaging>eclipse-plugin</packaging>
 <!--   <build> -->
 <!-- 	  <plugins> -->

--- a/framework/execution_framework/pom.xml
+++ b/framework/execution_framework/pom.xml
@@ -6,10 +6,10 @@
     <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
     	<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
     <modules>
         <!-- plugins -->

--- a/framework/execution_framework/pom.xml
+++ b/framework/execution_framework/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
-    	<version>3.0.0-SNAPSHOT</version>
+    	<version>4.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
     <modules>

--- a/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/feature.xml
+++ b/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.executionframework.feature"
       label="ModelDebugging Execution Framework"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/pom.xml
+++ b/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.executionframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.executionframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.executionframework.feature</artifactId>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.executionframework.reflectivetrace.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: INRIA
 Bundle-Localization: plugin

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.executionframework.reflectivetrace.model/pom.xml
@@ -17,10 +17,10 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.executionframework.reflectivetrace.model</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 </project>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: K3
 Bundle-SymbolicName: org.eclipse.gemoc.opsemanticsview.gen.k3;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.opsemanticsview.gen,
  fr.inria.diverse.melange.metamodel;bundle-version="0.2.0",

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen.k3/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 	<artifactId>org.eclipse.gemoc.opsemanticsview.gen.k3</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Opsemanticsviewgen
 Bundle-SymbolicName: org.eclipse.gemoc.opsemanticsview.gen;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.gen/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 	<artifactId>org.eclipse.gemoc.opsemanticsview.gen</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.opsemanticsview.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.opsemanticsview.model/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 	<artifactId>org.eclipse.gemoc.opsemanticsview.model</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Language Api
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.api;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.xdsmlframework.api.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.api</artifactId>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/META-INF/MANIFEST.MF
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.xdsmlframework.commons
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.commons
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.xtend.lib
 Export-Package: org.eclipse.gemoc.xdsmlframework.commons

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/pom.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.commons/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.commons</artifactId>

--- a/framework/framework_commons/pom.xml
+++ b/framework/framework_commons/pom.xml
@@ -3,12 +3,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
 	<artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modules>

--- a/framework/framework_commons/pom.xml
+++ b/framework/framework_commons/pom.xml
@@ -6,10 +6,10 @@
 	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
 		<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
 	<modules>
 		<!-- plugins -->

--- a/framework/framework_commons/releng/org.eclipse.gemoc.modeldebugging.framework.commons.feature/feature.xml
+++ b/framework/framework_commons/releng/org.eclipse.gemoc.modeldebugging.framework.commons.feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gemoc.modeldebugging.framework.commons.feature"
       label="ModelDebugging framework commons"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/framework/framework_commons/releng/org.eclipse.gemoc.modeldebugging.framework.commons.feature/pom.xml
+++ b/framework/framework_commons/releng/org.eclipse.gemoc.modeldebugging.framework.commons.feature/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.modeldebugging.framework.commons.feature</artifactId>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
+    <artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>    
+	<parent>
+		<groupId>org.eclipse.gemoc</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+    	<version>3.0.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	
+    <modules>    
+        <module>execution_framework</module>
+        <module>framework_commons</module>       
+        <module>xdsml_framework</module>
+    </modules>
+</project>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc extension for Sirius
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.extensions.sirius;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.xdsmlframework.extensions.sirius.Activator
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse.messagingsystem.api;bundle-version="1.0.0",

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/pom.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.extensions.sirius</artifactId>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ExecutionFramework Language Workbench UI
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.ide.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.xdsmlframework.ide.ui.Activator
 Bundle-Vendor: INRIA
 Require-Bundle: org.eclipse.core.runtime,

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/pom.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.ide.ui</artifactId>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Utils
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.ui.utils
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.xdsmlframework.ui.utils.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.codegen.ecore.ui;bundle-version="2.8.0",

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/pom.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.ui.utils</artifactId>

--- a/framework/xdsml_framework/pom.xml
+++ b/framework/xdsml_framework/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
 		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
-    	<version>3.0.0-SNAPSHOT</version>
+    	<version>4.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
     <modules>

--- a/framework/xdsml_framework/pom.xml
+++ b/framework/xdsml_framework/pom.xml
@@ -6,10 +6,10 @@
     <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
     	<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
     <modules>
         <!-- plugins -->

--- a/framework/xdsml_framework/releng/org.eclipse.gemoc.xdsmlframework.feature/feature.xml
+++ b/framework/xdsml_framework/releng/org.eclipse.gemoc.xdsmlframework.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.xdsmlframework.feature"
       label="ModelDebugging xdsml frameworks"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/framework/xdsml_framework/releng/org.eclipse.gemoc.xdsmlframework.feature/pom.xml
+++ b/framework/xdsml_framework/releng/org.eclipse.gemoc.xdsmlframework.feature/pom.xml
@@ -6,7 +6,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
     <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.xdsmlframework.feature</artifactId>

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: xdsmlframework Test library
 Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.test.lib
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.junit4;bundle-version="2.10.0",

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/pom.xml
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/pom.xml
@@ -6,7 +6,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.xdsmlframework.test.lib</artifactId>

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Sequential Language Workbench UI
 Bundle-SymbolicName: org.eclipse.gemoc.execution.sequential.javaengine.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator
 Bundle-Vendor: INRIA
 Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/pom.xml
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../../..</relativePath>
 		<groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
 		<artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.sequential.javaengine.ui</artifactId>

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Sequential Language Api
 Bundle-SymbolicName: org.eclipse.gemoc.execution.sequential.javaengine;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.execution.sequential.javaxdsml.api,
  org.eclipse.gemoc.executionframework.engine,

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/pom.xml
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../..</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaengine</artifactId>

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/META-INF/MANIFEST.MF
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Sequential Language Api
 Bundle-SymbolicName: org.eclipse.gemoc.execution.sequential.javaxdsml.api;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.executionframework.engine.ui,

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/pom.xml
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.api/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../..</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaxdsml.api</artifactId>

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Sequential Java XDSML UI
 Bundle-SymbolicName: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 4.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.Activator
 Bundle-Vendor: INRIA
 Require-Bundle: org.eclipse.core.runtime,

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/pom.xml
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../..</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui</artifactId>

--- a/java_execution/pom.xml
+++ b/java_execution/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.feature/feature.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gemoc.execution.sequential.javaengine.feature"
       label="Sequential Execution Engine Java"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.feature/pom.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.feature/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaengine.feature</artifactId>

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature/feature.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gemoc.execution.sequential.javaengine.ui.feature"
       label="Sequential Execution Engine Java UI"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature/pom.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaengine.ui.feature</artifactId>

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaxdsml.feature/feature.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaxdsml.feature/feature.xml
@@ -13,7 +13,7 @@
 <feature
       id="org.eclipse.gemoc.execution.sequential.javaxdsml.feature"
       label="Sequential Execution  Java XDSML"
-      version="3.0.0.qualifier"
+      version="4.0.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaxdsml.feature/pom.xml
+++ b/java_execution/releng/org.eclipse.gemoc.execution.sequential.javaxdsml.feature/pom.xml
@@ -17,7 +17,7 @@
     <relativePath>../../pom.xml</relativePath>
     <groupId>org.eclipse.gemoc.execution.sequential.java</groupId>
     <artifactId>org.eclipse.gemoc.execution.sequential.java.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.execution.sequential.javaxdsml.feature</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -337,12 +337,8 @@
 	            <activeByDefault>true</activeByDefault>
 	        </activation>
 	        <modules>
-	        	<module>trace/commons/pom.xml</module>
-	        	<module>trace/generator/pom.xml</module>
-	        	<module>trace/manager/pom.xml</module>
-	        	<module>framework/xdsml_framework/pom.xml</module>
-	        	<module>framework/execution_framework/pom.xml</module>
-	        	<module>framework/framework_commons/pom.xml</module>
+	        	<module>trace/pom.xml</module>
+	        	<module>framework/pom.xml</module>
 	        </modules>
 		</profile>
 		<profile>

--- a/releng/org.eclipse.gemoc.modeldebugging.repository/category.xml
+++ b/releng/org.eclipse.gemoc.modeldebugging.repository/category.xml
@@ -1,75 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.gemoc.trace.commons.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.trace.commons.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.commons.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.trace.commons.feature" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.trace.commons.feature_3.0.0.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.commons.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.commons.feature_3.0.1.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.commons.feature.source" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace.source"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.trace.generator.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.trace.generator.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.generator.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.trace.generator.feature" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.trace.generator.feature_3.0.0.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.generator.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.generator.feature_3.0.1.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.generator.feature.source" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace.source"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.trace.manager.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.trace.manager.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.manager.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.trace.manager.feature" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.trace.manager.feature_3.0.0.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.manager.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.trace.manager.feature_3.0.1.qualifier-sources-feature.jar" id="org.eclipse.gemoc.trace.manager.feature.source" version="3.0.1.qualifier">
       <category name="org.eclipse.gemoc.trace.source"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.xdsmlframework.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.xdsmlframework.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.xdsmlframework.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.xdsmlframework.feature" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.xdsmlframework.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.xdsmlframework.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.xdsmlframework.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.xdsmlframework.feature.source" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.executionframework.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.executionframework.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.executionframework.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.executionframework.feature" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.executionframework.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.executionframework.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.executionframework.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.executionframework.feature.source" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.modeldebugging.framework.commons.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.framework.commons.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.modeldebugging.framework.commons.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.framework.commons.feature" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.modeldebugging.framework.commons.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.framework.commons.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.modeldebugging.framework.commons.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.modeldebugging.framework.commons.feature.source" version="4.0.0.qualifier">
       <category name="ModelDebuggingFramework"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaxdsml.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaxdsml.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaxdsml.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaxdsml.feature" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaxdsml.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaxdsml.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaxdsml.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaxdsml.feature.source" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.feature" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.feature.source" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.ui.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.ui.feature" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.ui.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.execution.sequential.javaengine.ui.feature.source_4.0.0.qualifier.jar" id="org.eclipse.gemoc.execution.sequential.javaengine.ui.feature.source" version="4.0.0.qualifier">
       <category name="executionengine.java"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.feature" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.feature.source_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.feature.source" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.ui.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.ui.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.ui.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.ui.feature" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.ui.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.ui.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.ui.feature.source_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.ui.feature.source" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.sirius.ui.feature_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.sirius.ui.feature" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.sirius.ui.feature_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.sirius.ui.feature" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.dsl.debug.sirius.ui.feature.source_3.0.0.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.sirius.ui.feature.source" version="3.0.0.qualifier">
+   <feature url="features/org.eclipse.gemoc.dsl.debug.sirius.ui.feature.source_3.0.1.qualifier.jar" id="org.eclipse.gemoc.dsl.debug.sirius.ui.feature.source" version="3.0.1.qualifier">
       <category name="SimulationModelAnimation"/>
    </feature>
    <category-def name="org.eclipse.gemoc.trace" label="Multidimensional Domain-specific Trace Management Facilities">

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.edit;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.gemoc.dsl.debug.provider.DebugEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/pom.xml
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.edit/pom.xml
@@ -15,11 +15,11 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.edit</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.ide.sirius.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.debug.ui;bundle-version="3.7.0",

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/pom.xml
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/pom.xml
@@ -15,11 +15,11 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.ide.sirius.ui</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.ide.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.eclipse.debug.ui;bundle-version="3.7.0",

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/pom.xml
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.ui/pom.xml
@@ -15,11 +15,11 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.ide.ui</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.ide;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/pom.xml
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide/pom.xml
@@ -15,11 +15,11 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.ide</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/pom.xml
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug/pom.xml
@@ -15,11 +15,11 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>DSLDebugger</groupId>
 	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>DSL Debugger Parent</name>

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.feature/feature.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.dsl.debug.feature"
       label="DSL Debugger Feature"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.feature/pom.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.feature/pom.xml
@@ -15,12 +15,12 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <name>DSL Debugger Feature</name>

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.sirius.ui.feature/feature.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.sirius.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.dsl.debug.sirius.ui.feature"
       label="DSL Debugger Sirius UI Feature"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.sirius.ui.feature/pom.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.sirius.ui.feature/pom.xml
@@ -15,12 +15,12 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.sirius.ui.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <name>DSL Debugger Sirius UI Feature</name>

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.ui.feature/feature.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.dsl.debug.ui.feature"
       label="DSL Debugger UI Feature"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.ui.feature/pom.xml
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.ui.feature/pom.xml
@@ -15,12 +15,12 @@ Contributors:
   <parent>
   	<artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
   	<groupId>DSLDebugger</groupId>
-  	<version>3.0.0-SNAPSHOT</version>	
+  	<version>3.0.1-SNAPSHOT</version>	
   	<relativePath>../../</relativePath>
   </parent>
   <groupId>DSLDebugger</groupId>
   <artifactId>org.eclipse.gemoc.dsl.debug.ui.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <name>DSL Debugger UI Feature</name>

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.ide.tests
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.gemoc.dsl.debug.ide;bundle-version="1.0.0",

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/pom.xml
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.ide.tests/pom.xml
@@ -15,12 +15,12 @@ Contributors:
     <parent>
         <artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
         <groupId>DSLDebugger</groupId>
-        <version>3.0.0-SNAPSHOT</version>	
+        <version>3.0.1-SNAPSHOT</version>	
         <relativePath>../../</relativePath>
     </parent>
     <groupId>DSLDebugger</groupId>
     <artifactId>org.eclipse.gemoc.dsl.debug.ide.tests</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>eclipse-test-plugin</packaging>
 
     <properties>

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/META-INF/MANIFEST.MF
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.dsl.debug.tests;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/pom.xml
+++ b/simulationmodelanimation/tests/org.eclipse.gemoc.dsl.debug.tests/pom.xml
@@ -15,12 +15,12 @@ Contributors:
     <parent>
         <artifactId>org.eclipse.gemoc.dsl.debug.parent</artifactId>
         <groupId>DSLDebugger</groupId>
-        <version>3.0.0-SNAPSHOT</version>	
+        <version>3.0.1-SNAPSHOT</version>	
         <relativePath>../../</relativePath>
     </parent>
     <groupId>DSLDebugger</groupId>
     <artifactId>org.eclipse.gemoc.dsl.debug.tests</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>eclipse-test-plugin</packaging>
 
     <properties>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.commons.model;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: INRIA
 Bundle-Localization: plugin

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/pom.xml
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/pom.xml
@@ -17,10 +17,10 @@
     <relativePath>../..</relativePath>
     <groupId>org.eclipse.gemoc.trace.commons</groupId>
     <artifactId>org.eclipse.gemoc.trace.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.gemoc.trace.commons.model</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
 </project>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Util
 Bundle-SymbolicName: org.eclipse.gemoc.trace.commons
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Export-Package: org.eclipse.gemoc.trace.commons,
  org.eclipse.gemoc.trace.commons.tracemetamodel
 Require-Bundle: com.google.guava,

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons/pom.xml
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons/pom.xml
@@ -16,7 +16,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.trace.commons</groupId>
 	<artifactId>org.eclipse.gemoc.trace.commons</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.commons</groupId>
 		<artifactId>org.eclipse.gemoc.trace.commons.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Api
 Bundle-SymbolicName: org.eclipse.gemoc.trace.gemoc.api
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;bundle-version="2.10.2",

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/pom.xml
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.gemoc.api/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.trace.commons</groupId>
 	<artifactId>org.eclipse.gemoc.trace.gemoc.api</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.commons</groupId>
 		<artifactId>org.eclipse.gemoc.trace.commons.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/commons/pom.xml
+++ b/trace/commons/pom.xml
@@ -5,13 +5,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.trace.commons</groupId>
 	<artifactId>org.eclipse.gemoc.trace.commons.root</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace</groupId>
 		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/trace/commons/pom.xml
+++ b/trace/commons/pom.xml
@@ -9,10 +9,10 @@
 	<packaging>pom</packaging>
 
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.trace</groupId>
+		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
 		<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<modules>

--- a/trace/commons/releng/org.eclipse.gemoc.trace.commons.feature/feature.xml
+++ b/trace/commons/releng/org.eclipse.gemoc.trace.commons.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.trace.commons.feature"
       label="Domain Specific Trace Commons"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       image="gemocstudio32.png">
 
    <description url="http://www.example.com/description">

--- a/trace/commons/releng/org.eclipse.gemoc.trace.commons.feature/pom.xml
+++ b/trace/commons/releng/org.eclipse.gemoc.trace.commons.feature/pom.xml
@@ -15,13 +15,13 @@
 
   <groupId>org.eclipse.gemoc.trace.commons</groupId>
   <artifactId>org.eclipse.gemoc.trace.commons.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
    <parent>
     <groupId>org.eclipse.gemoc.trace.commons</groupId>
     <artifactId>org.eclipse.gemoc.trace.commons.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
    </parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.annotations.edit;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: tracingannotations.provider.TracingannotationsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.edit/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.annotations.edit</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.annotations.editor;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: tracingannotations.presentation.TracingannotationsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations.editor/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.annotations.editor</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.annotations;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.annotations/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.annotations</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.tracemm.k3al.generator
 Bundle-SymbolicName: org.eclipse.gemoc.trace.gemoc.generator;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.gemoc.generator</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.trace.gemoc.wizards
 Bundle-SymbolicName: org.eclipse.gemoc.trace.gemoc.ui;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.ui,

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/pom.xml
@@ -15,13 +15,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
   <artifactId>org.eclipse.gemoc.trace.gemoc.ui</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
    <parent>
     <groupId>org.eclipse.gemoc.trace.generator</groupId>
     <artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
    </parent>
   

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.tracemm.gemoctrace
 Bundle-SymbolicName: org.eclipse.gemoc.trace.gemoc;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.timeline;bundle-version="1.0.0",
  org.eclipse.gemoc.xdsmlframework.api;bundle-version="0.1.0",

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.gemoc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.metamodel.generator;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  com.google.guava,

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/pom.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.metamodel.generator/pom.xml
@@ -16,13 +16,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.multidimensional_trace_management</groupId>
 	<artifactId>org.eclipse.gemoc.trace.metamodel.generator</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.generator</groupId>
 		<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/trace/generator/pom.xml
+++ b/trace/generator/pom.xml
@@ -9,10 +9,10 @@
 	<packaging>pom</packaging>
 
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.trace</groupId>
+		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
 		<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<modules>

--- a/trace/generator/pom.xml
+++ b/trace/generator/pom.xml
@@ -5,13 +5,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.trace.generator</groupId>
 	<artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace</groupId>
 		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/trace/generator/releng/org.eclipse.gemoc.trace.generator.feature/feature.xml
+++ b/trace/generator/releng/org.eclipse.gemoc.trace.generator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.trace.generator.feature"
       label="Domain Specific Trace Metamodel Generator SDK"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       image="gemocstudio32.png">
 
    <description url="http://www.example.com/description">

--- a/trace/generator/releng/org.eclipse.gemoc.trace.generator.feature/pom.xml
+++ b/trace/generator/releng/org.eclipse.gemoc.trace.generator.feature/pom.xml
@@ -5,13 +5,13 @@
 
   <groupId>org.eclipse.gemoc.trace.generator</groupId>
   <artifactId>org.eclipse.gemoc.trace.generator.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
    <parent>
     <groupId>org.eclipse.gemoc.trace.generator</groupId>
     <artifactId>org.eclipse.gemoc.trace.generator.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
    </parent>
 

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Diffviewer
 Bundle-SymbolicName: org.eclipse.gemoc.addon.diffviewer;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-Activator: org.eclipse.gemoc.addon.diffviewer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/pom.xml
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/pom.xml
@@ -16,11 +16,11 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.manager</groupId>
 		<artifactId>org.eclipse.gemoc.trace.manager.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.addon.diffviewer</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 </project>

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc MultiDimensional Timeline Addon
 Bundle-SymbolicName: org.eclipse.gemoc.addon.multidimensional.timeline;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-Activator: org.eclipse.gemoc.addon.multidimensional.timeline.Activator
 Require-Bundle: org.eclipse.gemoc.timeline;bundle-version="1.0.0",
  org.eclipse.gemoc.executionframework.engine,

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/pom.xml
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.multidimensional.timeline/pom.xml
@@ -16,11 +16,11 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.manager</groupId>
 		<artifactId>org.eclipse.gemoc.trace.manager.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.addon.multidimensional.timeline</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 </project>

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/META-INF/MANIFEST.MF
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.addon.stategraph;singleton:=true
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/pom.xml
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.stategraph/pom.xml
@@ -16,11 +16,11 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.trace.manager</groupId>
 		<artifactId>org.eclipse.gemoc.trace.manager.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.addon.stategraph</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 </project>

--- a/trace/manager/pom.xml
+++ b/trace/manager/pom.xml
@@ -5,13 +5,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc.trace.manager</groupId>
 	<artifactId>org.eclipse.gemoc.trace.manager.root</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>org.eclipse.gemoc.trace</groupId>
 		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/trace/manager/pom.xml
+++ b/trace/manager/pom.xml
@@ -9,10 +9,10 @@
 	<packaging>pom</packaging>
 
 	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+		<groupId>org.eclipse.gemoc.trace</groupId>
+		<artifactId>org.eclipse.gemoc.trace.root</artifactId>
 		<version>3.0.0-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<modules>

--- a/trace/manager/releng/org.eclipse.gemoc.trace.manager.feature/feature.xml
+++ b/trace/manager/releng/org.eclipse.gemoc.trace.manager.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.trace.manager.feature"
       label="Domain Specific Trace Metamodel Manager SDK"
-      version="3.0.0.qualifier"
+      version="3.0.1.qualifier"
       image="gemocstudio32.png">
 
    <description url="http://www.example.com/description">

--- a/trace/manager/releng/org.eclipse.gemoc.trace.manager.feature/pom.xml
+++ b/trace/manager/releng/org.eclipse.gemoc.trace.manager.feature/pom.xml
@@ -5,13 +5,13 @@
 
   <groupId>org.eclipse.gemoc.trace.manager</groupId>
   <artifactId>org.eclipse.gemoc.trace.manager.feature</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
    <parent>
     <groupId>org.eclipse.gemoc.trace.manager</groupId>
     <artifactId>org.eclipse.gemoc.trace.manager.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
    </parent>
 

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.trace</groupId>
     <artifactId>org.eclipse.gemoc.trace.root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>    
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.eclipse.gemoc.trace</groupId>
+    <artifactId>org.eclipse.gemoc.trace.root</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>    
+	<parent>
+		<groupId>org.eclipse.gemoc</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
+    	<version>3.0.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	
+    <modules>    
+        <module>commons</module>
+        <module>generator</module>       
+        <module>manager</module>
+    </modules>
+</project>

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.commons.testutil/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.commons.testutil/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.trace.commons.test
 Bundle-SymbolicName: org.eclipse.gemoc.trace.commons.testutil
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.gemoc.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.gemoc.generator.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.trace.gemoc.generator.test
 Bundle-SymbolicName: org.eclipse.gemoc.trace.gemoc.generator.test
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.metamodel.generator.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.eclipse.gemoc.trace.metamodel.generator.test
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,

--- a/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.plugin.generator.test/META-INF/MANIFEST.MF
+++ b/trace/tests_and_benchmarks/org.eclipse.gemoc.trace.plugin.generator.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.trace.plugin.generator.test
 Bundle-SymbolicName: org.eclipse.gemoc.trace.plugin.generator.test
-Bundle-Version: 3.0.0.qualifier
+Bundle-Version: 3.0.1.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,


### PR DESCRIPTION
As we have done a release on 17 july 2018, in order to highlight the future new version and emphasis on significant changes, this PR increases the version of the Studio and some of its major components.

It follows suggestions of https://github.com/eclipse/gemoc-studio/issues/97 for the versionning schema. ie. product and components version will changes independently. We consider only major components: ie. main box of 
![image](https://user-images.githubusercontent.com/661468/42938596-171cd966-8b53-11e8-9fb0-b463fbc1b273.png)


This PR takes into account changes implied by https://github.com/eclipse/gemoc-studio-modeldebugging/pull/53 in order to bump the version of some main components of the studio:
- GEMOC Framework and java execution go to 4.0.0 due to major api changes
- Trace and SimulationModelAnimation go to 3.0.1 due to adaptation to these changes

The product id goes to 3.1.0 (including documentation and example deployers)

This PR comes simultaneously with https://github.com/eclipse/gemoc-studio/pull/101