### PR TITLE
Bump to latest k3/melange version

### DIFF
--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/WorkspaceTestHelper.xtend
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/WorkspaceTestHelper.xtend
@@ -73,6 +73,12 @@ class WorkspaceTestHelper {
 	 * we should increase this value up to the value where we don't have any false failed tests
 	 */ 
 	public static final int SWTBotPreferencesTIMEOUT_4_GEMOC = 8000;
+		/**
+	 * Value to use by default for SWTBotPreferences.PLAYBACK_DELAY 
+	 * It must be used for any GEMOC test using swtbot 
+	 * we should increase this value up to the value where we don't have any false failed tests
+	 */
+	public static final int SWTBotPreferencesPLAYBACK_DELAY_4_GEMOC = 100;
 	
 	def void init() {
 		

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
 		<tycho-version>1.0.0</tycho-version>
-    	<xtend.version>2.10.0</xtend.version>
+    	<xtend.version>2.12.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->		

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2018-06-04/</url>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2018-08-13/</url>
         </repository>
         <repository>
             <id>elk</id>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</modules>
 
     <properties>
-		<tycho-version>1.0.0</tycho-version>
+		<tycho-version>1.2.0</tycho-version>
     	<xtend.version>2.12.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
         <repository>
             <id>kermeta-3</id>
             <layout>p2</layout>
-            <url>http://www.kermeta.org/k3/update_2018-08-10</url>
+            <url>http://www.kermeta.org/k3/update_2018-08-14</url>
         </repository>
         <repository>
             <id>melange</id>
             <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2018-08-13/</url>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2018-08-14/</url>
         </repository>
         <repository>
             <id>elk</id>

--- a/pom.xml
+++ b/pom.xml
@@ -266,25 +266,6 @@
 						</configuration>
 					</execution>
 				</executions>
-				<!-- workaround  https://github.com/eclipse/xtext/issues/1231
-					may be removed when fixed later-->
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.jdt</groupId>
-						<artifactId>org.eclipse.jdt.core</artifactId>
-						<version>3.12.2</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.platform</groupId>
-						<artifactId>org.eclipse.core.runtime</artifactId>
-						<version>3.12.0</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.platform</groupId>
-						<artifactId>org.eclipse.equinox.common</artifactId>
-						<version>3.8.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
             <!-- Java compiler plugin -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	</modules>
 
     <properties>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.0.0</tycho-version>
     	<xtend.version>2.10.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <repository>
             <id>kermeta-3</id>
             <layout>p2</layout>
-            <url>http://www.kermeta.org/k3/update_2018-08-09</url>
+            <url>http://www.kermeta.org/k3/update_2018-08-10</url>
         </repository>
         <repository>
             <id>melange</id>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
 		<tycho-version>1.2.0</tycho-version>
-    	<xtend.version>2.12.0</xtend.version>
+    	<xtend.version>2.10.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->		

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <repository>
             <id>kermeta-3</id>
             <layout>p2</layout>
-            <url>http://www.kermeta.org/k3/update_2017-10-23</url>
+            <url>http://www.kermeta.org/k3/update_2018-08-09</url>
         </repository>
         <repository>
             <id>melange</id>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,25 @@
 						</configuration>
 					</execution>
 				</executions>
+				<!-- workaround  https://github.com/eclipse/xtext/issues/1231
+					may be removed when fixed later-->
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>3.12.2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.platform</groupId>
+						<artifactId>org.eclipse.core.runtime</artifactId>
+						<version>3.12.0</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.platform</groupId>
+						<artifactId>org.eclipse.equinox.common</artifactId>
+						<version>3.8.0</version>
+					</dependency>
+				</dependencies>
 			</plugin>
             <!-- Java compiler plugin -->
 			<plugin>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>1.0.0</tycho-version>
+		<tycho-version>1.2.0</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.0.0</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 


### PR DESCRIPTION
Bump version of K3 + Melange

Thjis includes some bug fixes such as [k3/issues/36](https://github.com/diverse-project/k3/issues/36), [k3/issues/58](https://github.com/diverse-project/k3/issues/58), [melange/issues/123](https://github.com/diverse-project/melange/issues/123) (should also have improvement on Melange stability)

Other version bump: tycho and xtend

companion PR: https://github.com/eclipse/gemoc-studio/pull/102