### PR TITLE
 Implement some missing eType in generic trace  and improve user feedback on RDT definition problems

### DIFF
--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.trace.commons.model;singleton:=true
 Bundle-Version: 3.0.1.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: INRIA
+Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.trace.commons.model.helper,

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.ecore
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTrace.ecore
@@ -1,159 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="trace" nsURI="http://www.gemoc.org/generic_trace" nsPrefix="trace">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="trace" nsURI="http://www.gemoc.org/generic_trace" nsPrefix="trace">
   <eClassifiers xsi:type="ecore:EDataType" name="ISerializable" instanceClassName="byte[]"/>
   <eClassifiers xsi:type="ecore:EClass" name="MSEOccurrence">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="mse" lowerBound="1" eType="//MSE"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="parameters" upperBound="-1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="result" upperBound="-1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="mse" lowerBound="1" eType="#//MSE"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="parameters" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="result" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="MSE" abstract="true">
-    <eSuperTypes href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//ENamedElement"/>
-    <eOperations name="getCaller">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
-    </eOperations>
-    <eOperations name="getAction">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
-    </eOperations>
+  <eClassifiers xsi:type="ecore:EClass" name="MSE" abstract="true" eSuperTypes="../../org.eclipse.emf.ecore/model/Ecore.ecore#//ENamedElement">
+    <eOperations name="getCaller" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
+    <eOperations name="getAction" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="MSEModel">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMSEs" upperBound="-1" eType="//MSE" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="ownedMSEs" upperBound="-1"
+        eType="#//MSE" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="GenericMSE" eSuperTypes="//MSE">
-    <eOperations name="getCaller">
+  <eClassifiers xsi:type="ecore:EClass" name="GenericMSE" eSuperTypes="#//MSE">
+    <eOperations name="getCaller" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return callerReference;"/>
       </eAnnotations>
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
     </eOperations>
-    <eOperations name="getAction">
+    <eOperations name="getAction" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="return actionReference;"/>
       </eAnnotations>
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="callerReference">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="actionReference">
-      <eType xsi:type="ecore:EClass" href="../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="callerReference" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="actionReference" eType="ecore:EClass ../../org.eclipse.emf.ecore/model/Ecore.ecore#//EOperation"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Step" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="mseoccurrence" eType="//MSEOccurrence" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="startingState" lowerBound="1" eOpposite="//State/startedSteps">
-      <eGenericType eTypeParameter="//Step/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="mseoccurrence" eType="#//MSEOccurrence"
+        containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="startingState" lowerBound="1"
+        eOpposite="#//State/startedSteps">
+      <eGenericType eTypeParameter="#//Step/StateSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="endingState" eOpposite="//State/endedSteps">
-      <eGenericType eTypeParameter="//Step/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endingState" eOpposite="#//State/endedSteps">
+      <eGenericType eTypeParameter="#//Step/StateSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BigStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//BigStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//BigStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="subSteps" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//BigStep/StepSubtype"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="subSteps" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//BigStep/StepSubtype"/>
     </eStructuralFeatures>
-    <eGenericSuperTypes eClassifier="//Step">
-      <eTypeArguments eTypeParameter="//BigStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//Step">
+      <eTypeArguments eTypeParameter="#//BigStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SmallStep" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//Step">
-      <eTypeArguments eTypeParameter="//SmallStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//Step">
+      <eTypeArguments eTypeParameter="#//SmallStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SequentialStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//SequentialStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//SequentialStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//BigStep">
-      <eTypeArguments eTypeParameter="//SequentialStep/StepSubtype"/>
-      <eTypeArguments eTypeParameter="//SequentialStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//BigStep">
+      <eTypeArguments eTypeParameter="#//SequentialStep/StepSubtype"/>
+      <eTypeArguments eTypeParameter="#//SequentialStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ParallelStep" abstract="true">
     <eTypeParameters name="StepSubtype">
-      <eBounds eClassifier="//Step">
-        <eTypeArguments eTypeParameter="//ParallelStep/StateSubType"/>
+      <eBounds eClassifier="#//Step">
+        <eTypeArguments eTypeParameter="#//ParallelStep/StateSubType"/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
-        <eTypeArguments eTypeParameter="//ParallelStep/StepSubtype"/>
+      <eBounds eClassifier="#//State">
+        <eTypeArguments eTypeParameter="#//ParallelStep/StepSubtype"/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eGenericSuperTypes eClassifier="//BigStep">
-      <eTypeArguments eTypeParameter="//ParallelStep/StepSubtype"/>
-      <eTypeArguments eTypeParameter="//ParallelStep/StateSubType"/>
+    <eGenericSuperTypes eClassifier="#//BigStep">
+      <eTypeArguments eTypeParameter="#//ParallelStep/StepSubtype"/>
+      <eTypeArguments eTypeParameter="#//ParallelStep/StateSubType"/>
     </eGenericSuperTypes>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Trace" abstract="true">
     <eTypeParameters name="StepSubType">
-      <eBounds eClassifier="//Step">
+      <eBounds eClassifier="#//Step">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="TracedObjectSubtype">
-      <eBounds eClassifier="//TracedObject">
+      <eBounds eClassifier="#//TracedObject">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="rootStep" lowerBound="1" containment="true">
-      <eGenericType eTypeParameter="//Trace/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="rootStep" lowerBound="1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Trace/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" ordered="false" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Trace/TracedObjectSubtype"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="tracedObjects" ordered="false"
+        upperBound="-1" containment="true">
+      <eGenericType eTypeParameter="#//Trace/TracedObjectSubtype"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Trace/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Trace/StateSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="launchconfiguration" lowerBound="1" containment="true">
-      <eType xsi:type="ecore:EClass" href="LaunchConfiguration.ecore#//LaunchConfiguration"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="launchconfiguration" lowerBound="1"
+        eType="ecore:EClass LaunchConfiguration.ecore#//LaunchConfiguration" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="TracedObject" abstract="true">
     <eTypeParameters name="DimensionSubType">
-      <eBounds eClassifier="//Dimension">
+      <eBounds eClassifier="#//Dimension">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
@@ -161,55 +155,61 @@
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="body" value="// Default implementation, returning empty list.&#xA;final EList&lt;DimensionSubType> result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;DimensionSubType>(Object.class);&#xA;return result;"/>
       </eAnnotations>
-      <eGenericType eTypeParameter="//TracedObject/DimensionSubType"/>
+      <eGenericType eTypeParameter="#//TracedObject/DimensionSubType"/>
     </eOperations>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensions" upperBound="-1" volatile="true" transient="true" derived="true">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="dimensions" upperBound="-1"
+        volatile="true" transient="true" derived="true">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="get" value="return getDimensionsInternal();"/>
       </eAnnotations>
-      <eGenericType eTypeParameter="//TracedObject/DimensionSubType"/>
+      <eGenericType eTypeParameter="#//TracedObject/DimensionSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Dimension" abstract="true">
     <eTypeParameters name="ValueSubType">
-      <eBounds eClassifier="//Value">
+      <eBounds eClassifier="#//Value">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1" containment="true">
-      <eGenericType eTypeParameter="//Dimension/ValueSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" upperBound="-1"
+        containment="true">
+      <eGenericType eTypeParameter="#//Dimension/ValueSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Value" abstract="true">
     <eTypeParameters name="StateSubType">
-      <eBounds eClassifier="//State">
+      <eBounds eClassifier="#//State">
         <eTypeArguments/>
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1" eOpposite="//State/values">
-      <eGenericType eTypeParameter="//Value/StateSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
+        eOpposite="#//State/values">
+      <eGenericType eTypeParameter="#//Value/StateSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="State" abstract="true">
     <eTypeParameters name="StepSubType">
-      <eBounds eClassifier="//Step">
+      <eBounds eClassifier="#//Step">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
     <eTypeParameters name="ValueSubType">
-      <eBounds eClassifier="//Value">
+      <eBounds eClassifier="#//Value">
         <eTypeArguments/>
       </eBounds>
     </eTypeParameters>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="startedSteps" upperBound="-1" eOpposite="//Step/startingState">
-      <eGenericType eTypeParameter="//State/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="startedSteps" upperBound="-1"
+        eOpposite="#//Step/startingState">
+      <eGenericType eTypeParameter="#//State/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="endedSteps" upperBound="-1" eOpposite="//Step/endingState">
-      <eGenericType eTypeParameter="//State/StepSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="endedSteps" upperBound="-1"
+        eOpposite="#//Step/endingState">
+      <eGenericType eTypeParameter="#//State/StepSubType"/>
     </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="values" ordered="false" upperBound="-1" eOpposite="//Value/states">
-      <eGenericType eTypeParameter="//State/ValueSubType"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="values" ordered="false"
+        upperBound="-1" eOpposite="#//Value/states">
+      <eGenericType eTypeParameter="#//State/ValueSubType"/>
     </eStructuralFeatures>
   </eClassifiers>
 </ecore:EPackage>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.ecore
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.ecore
@@ -104,4 +104,24 @@
   <eClassifiers xsi:type="ecore:EClass" name="IntegerObjectAttributeValue" eSuperTypes="#//GenericAttributeValue">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EIntegerObject"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DoubleAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ManyDoubleAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="DoubleObjectAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDoubleObject"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LongAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELong"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ManyLongAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELong"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="LongObjectAttributeValue" eSuperTypes="#//GenericAttributeValue">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="attributeValue" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELongObject"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.genmodel
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/model/GenericTraceImpl.genmodel
@@ -12,21 +12,17 @@
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericSequentialStep"/>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericParallelStep"/>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericSmallStep"/>
-    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericReferenceValue">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericReferenceValue/referenceValue"/>
-    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericReferenceValue"/>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericDimension">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericDimension/dynamicProperty"/>
     </genClasses>
-    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericTracedObject"/>
-    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericState">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericState/valuesRef"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericState/startedStepsRef"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericState/endedStepsRef"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericState/getValues"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericState/getStartedSteps"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericState/getEndedSteps"/>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericTracedObject">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericTracedObject/originalObject"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericTracedObject/allDimensions"/>
+      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericTracedObject/getDimensionsInternal"
+          body="final EList&lt;GenericDimension> result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;GenericDimension>(Object.class);&#xA;result.addAll(super.getDimensionsInternal());&#xA;result.addAll(getAllDimensions());&#xA;return result;&#xA;"/>
     </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericState"/>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//GenericTrace">
       <genTypeParameters ecoreTypeParameter="GenericTraceImpl.ecore#//GenericTrace/StepSubType"/>
     </genClasses>
@@ -34,21 +30,49 @@
     <genClasses ecoreClass="GenericTraceImpl.ecore#//BooleanAttributeValue">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//BooleanAttributeValue/attributeValue"/>
     </genClasses>
-    <genClasses ecoreClass="GenericTraceImpl.ecore#//IntegerAttributevalue">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//IntegerAttributevalue/attributeValue"/>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//IntegerAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//IntegerAttributeValue/attributeValue"/>
     </genClasses>
     <genClasses ecoreClass="GenericTraceImpl.ecore#//StringAttributeValue">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//StringAttributeValue/attributeValue"/>
     </genClasses>
-    <genClasses image="false" ecoreClass="GenericTraceImpl.ecore#//GenericStep">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericStep/startingStateRef"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericStep/endingStateRef"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericStep/getStartingState"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericStep/getEndingState"/>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyBooleanAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//ManyBooleanAttributeValue/attributeValue"/>
     </genClasses>
-    <genClasses image="false" ecoreClass="GenericTraceImpl.ecore#//GenericValue">
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//GenericValue/statesRef"/>
-      <genOperations ecoreOperation="GenericTraceImpl.ecore#//GenericValue/getStates"/>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyIntegerAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//ManyIntegerAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyStringAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//ManyStringAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses image="false" ecoreClass="GenericTraceImpl.ecore#//GenericStep"/>
+    <genClasses image="false" ecoreClass="GenericTraceImpl.ecore#//GenericValue"/>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//SingleReferenceValue">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//SingleReferenceValue/referenceValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyReferenceValue">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference GenericTraceImpl.ecore#//ManyReferenceValue/referenceValues"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//IntegerObjectAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//IntegerObjectAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//DoubleAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//DoubleAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyDoubleAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//ManyDoubleAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//DoubleObjectAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//DoubleObjectAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//LongAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//LongAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//ManyLongAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//ManyLongAttributeValue/attributeValue"/>
+    </genClasses>
+    <genClasses ecoreClass="GenericTraceImpl.ecore#//LongObjectAttributeValue">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute GenericTraceImpl.ecore#//LongObjectAttributeValue/attributeValue"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/plugin.properties
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = Generic Trace Model
-providerName = www.example.org
+providerName = Inria

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/DoubleAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/DoubleAttributeValue.java
@@ -1,0 +1,49 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Double Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getDoubleAttributeValue()
+ * @model
+ * @generated
+ */
+public interface DoubleAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute.
+	 * @see #setAttributeValue(double)
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getDoubleAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	double getAttributeValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue#getAttributeValue <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Attribute Value</em>' attribute.
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
+	void setAttributeValue(double value);
+
+} // DoubleAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/DoubleObjectAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/DoubleObjectAttributeValue.java
@@ -1,0 +1,49 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Double Object Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getDoubleObjectAttributeValue()
+ * @model
+ * @generated
+ */
+public interface DoubleObjectAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute.
+	 * @see #setAttributeValue(Double)
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getDoubleObjectAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	Double getAttributeValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Attribute Value</em>' attribute.
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
+	void setAttributeValue(Double value);
+
+} // DoubleObjectAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenericTracedObject.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenericTracedObject.java
@@ -81,7 +81,7 @@ public interface GenericTracedObject extends TracedObject<GenericDimension> {
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @model kind="operation"
-	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList<GenericDimension> result = new org.eclipse.emf.ecore.util.BasicInternalEList<GenericDimension>(Object.class);\nresult.addAll(super.getDimensionsInternal());\nresult.addAll(getAllDimensions());\nreturn result;\n'"
+	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='final EList&lt;GenericDimension&gt; result = new org.eclipse.emf.ecore.util.BasicInternalEList&lt;GenericDimension&gt;(Object.class);\nresult.addAll(super.getDimensionsInternal());\nresult.addAll(getAllDimensions());\nreturn result;\n'"
 	 * @generated
 	 */
 	EList<GenericDimension> getDimensionsInternal();

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenerictraceFactory.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenerictraceFactory.java
@@ -176,6 +176,60 @@ public interface GenerictraceFactory extends EFactory {
 	IntegerObjectAttributeValue createIntegerObjectAttributeValue();
 
 	/**
+	 * Returns a new object of class '<em>Double Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Double Attribute Value</em>'.
+	 * @generated
+	 */
+	DoubleAttributeValue createDoubleAttributeValue();
+
+	/**
+	 * Returns a new object of class '<em>Many Double Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Many Double Attribute Value</em>'.
+	 * @generated
+	 */
+	ManyDoubleAttributeValue createManyDoubleAttributeValue();
+
+	/**
+	 * Returns a new object of class '<em>Double Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Double Object Attribute Value</em>'.
+	 * @generated
+	 */
+	DoubleObjectAttributeValue createDoubleObjectAttributeValue();
+
+	/**
+	 * Returns a new object of class '<em>Long Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Long Attribute Value</em>'.
+	 * @generated
+	 */
+	LongAttributeValue createLongAttributeValue();
+
+	/**
+	 * Returns a new object of class '<em>Many Long Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Many Long Attribute Value</em>'.
+	 * @generated
+	 */
+	ManyLongAttributeValue createManyLongAttributeValue();
+
+	/**
+	 * Returns a new object of class '<em>Long Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return a new object of class '<em>Long Object Attribute Value</em>'.
+	 * @generated
+	 */
+	LongObjectAttributeValue createLongObjectAttributeValue();
+
+	/**
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenerictracePackage.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/GenerictracePackage.java
@@ -1063,13 +1063,289 @@ public interface GenerictracePackage extends EPackage {
 	int INTEGER_OBJECT_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleAttributeValueImpl <em>Double Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getDoubleAttributeValue()
+	 * @generated
+	 */
+	int DOUBLE_ATTRIBUTE_VALUE = 20;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Double Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Double Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyDoubleAttributeValueImpl <em>Many Double Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyDoubleAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getManyDoubleAttributeValue()
+	 * @generated
+	 */
+	int MANY_DOUBLE_ATTRIBUTE_VALUE = 21;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_DOUBLE_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Many Double Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_DOUBLE_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Many Double Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_DOUBLE_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleObjectAttributeValueImpl <em>Double Object Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleObjectAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getDoubleObjectAttributeValue()
+	 * @generated
+	 */
+	int DOUBLE_OBJECT_ATTRIBUTE_VALUE = 22;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_OBJECT_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Double Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_OBJECT_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Double Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DOUBLE_OBJECT_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongAttributeValueImpl <em>Long Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getLongAttributeValue()
+	 * @generated
+	 */
+	int LONG_ATTRIBUTE_VALUE = 23;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Long Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Long Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyLongAttributeValueImpl <em>Many Long Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyLongAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getManyLongAttributeValue()
+	 * @generated
+	 */
+	int MANY_LONG_ATTRIBUTE_VALUE = 24;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_LONG_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Many Long Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_LONG_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Many Long Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MANY_LONG_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongObjectAttributeValueImpl <em>Long Object Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongObjectAttributeValueImpl
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getLongObjectAttributeValue()
+	 * @generated
+	 */
+	int LONG_OBJECT_ATTRIBUTE_VALUE = 25;
+
+	/**
+	 * The feature id for the '<em><b>States</b></em>' reference list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_OBJECT_ATTRIBUTE_VALUE__STATES = GENERIC_ATTRIBUTE_VALUE__STATES;
+
+	/**
+	 * The feature id for the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
+
+	/**
+	 * The number of structural features of the '<em>Long Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_OBJECT_ATTRIBUTE_VALUE_FEATURE_COUNT = GENERIC_ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
+
+	/**
+	 * The number of operations of the '<em>Long Object Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LONG_OBJECT_ATTRIBUTE_VALUE_OPERATION_COUNT = GENERIC_ATTRIBUTE_VALUE_OPERATION_COUNT + 0;
+
+	/**
 	 * The meta object id for the '<em>ISerializable</em>' data type.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getISerializable()
 	 * @generated
 	 */
-	int ISERIALIZABLE = 20;
+	int ISERIALIZABLE = 26;
 
 
 	/**
@@ -1415,6 +1691,132 @@ public interface GenerictracePackage extends EPackage {
 	EAttribute getIntegerObjectAttributeValue_AttributeValue();
 
 	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue <em>Double Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Double Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue
+	 * @generated
+	 */
+	EClass getDoubleAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue#getAttributeValue()
+	 * @see #getDoubleAttributeValue()
+	 * @generated
+	 */
+	EAttribute getDoubleAttributeValue_AttributeValue();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue <em>Many Double Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Many Double Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue
+	 * @generated
+	 */
+	EClass getManyDoubleAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute list '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute list '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue#getAttributeValue()
+	 * @see #getManyDoubleAttributeValue()
+	 * @generated
+	 */
+	EAttribute getManyDoubleAttributeValue_AttributeValue();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue <em>Double Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Double Object Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue
+	 * @generated
+	 */
+	EClass getDoubleObjectAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue#getAttributeValue()
+	 * @see #getDoubleObjectAttributeValue()
+	 * @generated
+	 */
+	EAttribute getDoubleObjectAttributeValue_AttributeValue();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue <em>Long Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Long Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue
+	 * @generated
+	 */
+	EClass getLongAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue#getAttributeValue()
+	 * @see #getLongAttributeValue()
+	 * @generated
+	 */
+	EAttribute getLongAttributeValue_AttributeValue();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue <em>Many Long Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Many Long Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue
+	 * @generated
+	 */
+	EClass getManyLongAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute list '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute list '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue#getAttributeValue()
+	 * @see #getManyLongAttributeValue()
+	 * @generated
+	 */
+	EAttribute getManyLongAttributeValue_AttributeValue();
+
+	/**
+	 * Returns the meta object for class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue <em>Long Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>Long Object Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue
+	 * @generated
+	 */
+	EClass getLongObjectAttributeValue();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Attribute Value</em>'.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue#getAttributeValue()
+	 * @see #getLongObjectAttributeValue()
+	 * @generated
+	 */
+	EAttribute getLongObjectAttributeValue_AttributeValue();
+
+	/**
 	 * Returns the meta object for data type '<em>ISerializable</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1750,6 +2152,114 @@ public interface GenerictracePackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getIntegerObjectAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleAttributeValueImpl <em>Double Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getDoubleAttributeValue()
+		 * @generated
+		 */
+		EClass DOUBLE_ATTRIBUTE_VALUE = eINSTANCE.getDoubleAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getDoubleAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyDoubleAttributeValueImpl <em>Many Double Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyDoubleAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getManyDoubleAttributeValue()
+		 * @generated
+		 */
+		EClass MANY_DOUBLE_ATTRIBUTE_VALUE = eINSTANCE.getManyDoubleAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getManyDoubleAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleObjectAttributeValueImpl <em>Double Object Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleObjectAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getDoubleObjectAttributeValue()
+		 * @generated
+		 */
+		EClass DOUBLE_OBJECT_ATTRIBUTE_VALUE = eINSTANCE.getDoubleObjectAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getDoubleObjectAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongAttributeValueImpl <em>Long Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getLongAttributeValue()
+		 * @generated
+		 */
+		EClass LONG_ATTRIBUTE_VALUE = eINSTANCE.getLongAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getLongAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyLongAttributeValueImpl <em>Many Long Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyLongAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getManyLongAttributeValue()
+		 * @generated
+		 */
+		EClass MANY_LONG_ATTRIBUTE_VALUE = eINSTANCE.getManyLongAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getManyLongAttributeValue_AttributeValue();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongObjectAttributeValueImpl <em>Long Object Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongObjectAttributeValueImpl
+		 * @see org.eclipse.gemoc.trace.commons.model.generictrace.impl.GenerictracePackageImpl#getLongObjectAttributeValue()
+		 * @generated
+		 */
+		EClass LONG_OBJECT_ATTRIBUTE_VALUE = eINSTANCE.getLongObjectAttributeValue();
+
+		/**
+		 * The meta object literal for the '<em><b>Attribute Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE = eINSTANCE.getLongObjectAttributeValue_AttributeValue();
 
 		/**
 		 * The meta object literal for the '<em>ISerializable</em>' data type.

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/LongAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/LongAttributeValue.java
@@ -1,0 +1,49 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Long Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getLongAttributeValue()
+ * @model
+ * @generated
+ */
+public interface LongAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute.
+	 * @see #setAttributeValue(long)
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getLongAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	long getAttributeValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue#getAttributeValue <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Attribute Value</em>' attribute.
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
+	void setAttributeValue(long value);
+
+} // LongAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/LongObjectAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/LongObjectAttributeValue.java
@@ -1,0 +1,49 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Long Object Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getLongObjectAttributeValue()
+ * @model
+ * @generated
+ */
+public interface LongObjectAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute.
+	 * @see #setAttributeValue(Long)
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getLongObjectAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	Long getAttributeValue();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue#getAttributeValue <em>Attribute Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Attribute Value</em>' attribute.
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
+	void setAttributeValue(Long value);
+
+} // LongObjectAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/ManyDoubleAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/ManyDoubleAttributeValue.java
@@ -1,0 +1,40 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+import org.eclipse.emf.common.util.EList;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Many Double Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getManyDoubleAttributeValue()
+ * @model
+ * @generated
+ */
+public interface ManyDoubleAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute list.
+	 * The list contents are of type {@link java.lang.Double}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute list isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute list.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getManyDoubleAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	EList<Double> getAttributeValue();
+
+} // ManyDoubleAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/ManyLongAttributeValue.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/ManyLongAttributeValue.java
@@ -1,0 +1,40 @@
+/**
+ */
+package org.eclipse.gemoc.trace.commons.model.generictrace;
+
+import org.eclipse.emf.common.util.EList;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Many Long Attribute Value</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * </p>
+ * <ul>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue#getAttributeValue <em>Attribute Value</em>}</li>
+ * </ul>
+ *
+ * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getManyLongAttributeValue()
+ * @model
+ * @generated
+ */
+public interface ManyLongAttributeValue extends GenericAttributeValue {
+	/**
+	 * Returns the value of the '<em><b>Attribute Value</b></em>' attribute list.
+	 * The list contents are of type {@link java.lang.Long}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Attribute Value</em>' attribute list isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Attribute Value</em>' attribute list.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage#getManyLongAttributeValue_AttributeValue()
+	 * @model
+	 * @generated
+	 */
+	EList<Long> getAttributeValue();
+
+} // ManyLongAttributeValue

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/DoubleAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/DoubleAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
 
 import org.eclipse.emf.common.notify.Notification;
 
@@ -21,46 +8,49 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Double Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.BooleanAttributeValueImpl#isAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class BooleanAttributeValueImpl extends GenericAttributeValueImpl implements BooleanAttributeValue {
+public class DoubleAttributeValueImpl extends GenericAttributeValueImpl implements DoubleAttributeValue {
 	/**
-	 * The default value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The default value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean ATTRIBUTE_VALUE_EDEFAULT = false;
+	protected static final double ATTRIBUTE_VALUE_EDEFAULT = 0.0;
 
 	/**
-	 * The cached value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected boolean attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
+	protected double attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected BooleanAttributeValueImpl() {
+	protected DoubleAttributeValueImpl() {
 		super();
 	}
 
@@ -71,7 +61,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.BOOLEAN_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.DOUBLE_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -79,7 +69,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isAttributeValue() {
+	public double getAttributeValue() {
 		return attributeValue;
 	}
 
@@ -88,11 +78,11 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setAttributeValue(boolean newAttributeValue) {
-		boolean oldAttributeValue = attributeValue;
+	public void setAttributeValue(double newAttributeValue) {
+		double oldAttributeValue = attributeValue;
 		attributeValue = newAttributeValue;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
+			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
 	}
 
 	/**
@@ -103,8 +93,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return isAttributeValue();
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -117,8 +107,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				setAttributeValue((Boolean)newValue);
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue((Double)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -132,7 +122,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				setAttributeValue(ATTRIBUTE_VALUE_EDEFAULT);
 				return;
 		}
@@ -147,7 +137,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return attributeValue != ATTRIBUTE_VALUE_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
@@ -169,4 +159,4 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 		return result.toString();
 	}
 
-} //BooleanAttributeValueImpl
+} //DoubleAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/DoubleObjectAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/DoubleObjectAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
 
 import org.eclipse.emf.common.notify.Notification;
 
@@ -21,46 +8,49 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Double Object Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.BooleanAttributeValueImpl#isAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.DoubleObjectAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class BooleanAttributeValueImpl extends GenericAttributeValueImpl implements BooleanAttributeValue {
+public class DoubleObjectAttributeValueImpl extends GenericAttributeValueImpl implements DoubleObjectAttributeValue {
 	/**
-	 * The default value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The default value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean ATTRIBUTE_VALUE_EDEFAULT = false;
+	protected static final Double ATTRIBUTE_VALUE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected boolean attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
+	protected Double attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected BooleanAttributeValueImpl() {
+	protected DoubleObjectAttributeValueImpl() {
 		super();
 	}
 
@@ -71,7 +61,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.BOOLEAN_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.DOUBLE_OBJECT_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -79,7 +69,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isAttributeValue() {
+	public Double getAttributeValue() {
 		return attributeValue;
 	}
 
@@ -88,11 +78,11 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setAttributeValue(boolean newAttributeValue) {
-		boolean oldAttributeValue = attributeValue;
+	public void setAttributeValue(Double newAttributeValue) {
+		Double oldAttributeValue = attributeValue;
 		attributeValue = newAttributeValue;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
+			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
 	}
 
 	/**
@@ -103,8 +93,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return isAttributeValue();
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -117,8 +107,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				setAttributeValue((Boolean)newValue);
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue((Double)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -132,7 +122,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				setAttributeValue(ATTRIBUTE_VALUE_EDEFAULT);
 				return;
 		}
@@ -147,8 +137,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return attributeValue != ATTRIBUTE_VALUE_EDEFAULT;
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return ATTRIBUTE_VALUE_EDEFAULT == null ? attributeValue != null : !ATTRIBUTE_VALUE_EDEFAULT.equals(attributeValue);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -169,4 +159,4 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 		return result.toString();
 	}
 
-} //BooleanAttributeValueImpl
+} //DoubleObjectAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/GenerictraceFactoryImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/GenerictraceFactoryImpl.java
@@ -83,6 +83,12 @@ public class GenerictraceFactoryImpl extends EFactoryImpl implements Generictrac
 			case GenerictracePackage.SINGLE_REFERENCE_VALUE: return createSingleReferenceValue();
 			case GenerictracePackage.MANY_REFERENCE_VALUE: return createManyReferenceValue();
 			case GenerictracePackage.INTEGER_OBJECT_ATTRIBUTE_VALUE: return createIntegerObjectAttributeValue();
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE: return createDoubleAttributeValue();
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE: return createManyDoubleAttributeValue();
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE: return createDoubleObjectAttributeValue();
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE: return createLongAttributeValue();
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE: return createManyLongAttributeValue();
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE: return createLongObjectAttributeValue();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -276,6 +282,66 @@ public class GenerictraceFactoryImpl extends EFactoryImpl implements Generictrac
 	public IntegerObjectAttributeValue createIntegerObjectAttributeValue() {
 		IntegerObjectAttributeValueImpl integerObjectAttributeValue = new IntegerObjectAttributeValueImpl();
 		return integerObjectAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public DoubleAttributeValue createDoubleAttributeValue() {
+		DoubleAttributeValueImpl doubleAttributeValue = new DoubleAttributeValueImpl();
+		return doubleAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public ManyDoubleAttributeValue createManyDoubleAttributeValue() {
+		ManyDoubleAttributeValueImpl manyDoubleAttributeValue = new ManyDoubleAttributeValueImpl();
+		return manyDoubleAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public DoubleObjectAttributeValue createDoubleObjectAttributeValue() {
+		DoubleObjectAttributeValueImpl doubleObjectAttributeValue = new DoubleObjectAttributeValueImpl();
+		return doubleObjectAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public LongAttributeValue createLongAttributeValue() {
+		LongAttributeValueImpl longAttributeValue = new LongAttributeValueImpl();
+		return longAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public ManyLongAttributeValue createManyLongAttributeValue() {
+		ManyLongAttributeValueImpl manyLongAttributeValue = new ManyLongAttributeValueImpl();
+		return manyLongAttributeValue;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public LongObjectAttributeValue createLongObjectAttributeValue() {
+		LongObjectAttributeValueImpl longObjectAttributeValue = new LongObjectAttributeValueImpl();
+		return longObjectAttributeValue;
 	}
 
 	/**

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/GenerictracePackageImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/GenerictracePackageImpl.java
@@ -13,6 +13,8 @@
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
 
 import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericDimension;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericParallelStep;
@@ -28,13 +30,18 @@ import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictraceFactory;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
 import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerObjectAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyBooleanAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyIntegerAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyStringAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.SingleReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.StringAttributeValue;
 
+import org.eclipse.gemoc.trace.commons.model.launchconfiguration.LaunchconfigurationPackage;
 import org.eclipse.gemoc.trace.commons.model.trace.TracePackage;
 
 import org.eclipse.emf.ecore.EAttribute;
@@ -201,6 +208,48 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	private EClass doubleAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass manyDoubleAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass doubleObjectAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass longAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass manyLongAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass longObjectAttributeValueEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	private EDataType iSerializableEDataType = null;
 
 	/**
@@ -231,7 +280,7 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
+	 *
 	 * <p>This method is used to initialize {@link GenerictracePackage#eINSTANCE} when that field is accessed.
 	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
 	 * <!-- begin-user-doc -->
@@ -245,12 +294,15 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 		if (isInited) return (GenerictracePackage)EPackage.Registry.INSTANCE.getEPackage(GenerictracePackage.eNS_URI);
 
 		// Obtain or create and register package
-		GenerictracePackageImpl theGenerictracePackage = (GenerictracePackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof GenerictracePackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new GenerictracePackageImpl());
+		Object registeredGenerictracePackage = EPackage.Registry.INSTANCE.get(eNS_URI);
+		GenerictracePackageImpl theGenerictracePackage = registeredGenerictracePackage instanceof GenerictracePackageImpl ? (GenerictracePackageImpl)registeredGenerictracePackage : new GenerictracePackageImpl();
 
 		isInited = true;
 
 		// Initialize simple dependencies
+		EcorePackage.eINSTANCE.eClass();
 		TracePackage.eINSTANCE.eClass();
+		LaunchconfigurationPackage.eINSTANCE.eClass();
 
 		// Create package meta-data objects
 		theGenerictracePackage.createPackageContents();
@@ -261,7 +313,6 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 		// Mark meta-data to indicate it can't be changed
 		theGenerictracePackage.freeze();
 
-  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(GenerictracePackage.eNS_URI, theGenerictracePackage);
 		return theGenerictracePackage;
@@ -569,6 +620,114 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EClass getDoubleAttributeValue() {
+		return doubleAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getDoubleAttributeValue_AttributeValue() {
+		return (EAttribute)doubleAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getManyDoubleAttributeValue() {
+		return manyDoubleAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getManyDoubleAttributeValue_AttributeValue() {
+		return (EAttribute)manyDoubleAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getDoubleObjectAttributeValue() {
+		return doubleObjectAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getDoubleObjectAttributeValue_AttributeValue() {
+		return (EAttribute)doubleObjectAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getLongAttributeValue() {
+		return longAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getLongAttributeValue_AttributeValue() {
+		return (EAttribute)longAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getManyLongAttributeValue() {
+		return manyLongAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getManyLongAttributeValue_AttributeValue() {
+		return (EAttribute)manyLongAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EClass getLongObjectAttributeValue() {
+		return longObjectAttributeValueEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getLongObjectAttributeValue_AttributeValue() {
+		return (EAttribute)longObjectAttributeValueEClass.getEStructuralFeatures().get(0);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EDataType getISerializable() {
 		return iSerializableEDataType;
 	}
@@ -653,6 +812,24 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 
 		integerObjectAttributeValueEClass = createEClass(INTEGER_OBJECT_ATTRIBUTE_VALUE);
 		createEAttribute(integerObjectAttributeValueEClass, INTEGER_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		doubleAttributeValueEClass = createEClass(DOUBLE_ATTRIBUTE_VALUE);
+		createEAttribute(doubleAttributeValueEClass, DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		manyDoubleAttributeValueEClass = createEClass(MANY_DOUBLE_ATTRIBUTE_VALUE);
+		createEAttribute(manyDoubleAttributeValueEClass, MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		doubleObjectAttributeValueEClass = createEClass(DOUBLE_OBJECT_ATTRIBUTE_VALUE);
+		createEAttribute(doubleObjectAttributeValueEClass, DOUBLE_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		longAttributeValueEClass = createEClass(LONG_ATTRIBUTE_VALUE);
+		createEAttribute(longAttributeValueEClass, LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		manyLongAttributeValueEClass = createEClass(MANY_LONG_ATTRIBUTE_VALUE);
+		createEAttribute(manyLongAttributeValueEClass, MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+
+		longObjectAttributeValueEClass = createEClass(LONG_OBJECT_ATTRIBUTE_VALUE);
+		createEAttribute(longObjectAttributeValueEClass, LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
 
 		// Create data types
 		iSerializableEDataType = createEDataType(ISERIALIZABLE);
@@ -756,6 +933,12 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 		singleReferenceValueEClass.getESuperTypes().add(this.getGenericReferenceValue());
 		manyReferenceValueEClass.getESuperTypes().add(this.getGenericReferenceValue());
 		integerObjectAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		doubleAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		manyDoubleAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		doubleObjectAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		longAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		manyLongAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
+		longObjectAttributeValueEClass.getESuperTypes().add(this.getGenericAttributeValue());
 
 		// Initialize classes, features, and operations; add parameters
 		initEClass(genericSequentialStepEClass, GenericSequentialStep.class, "GenericSequentialStep", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -811,6 +994,24 @@ public class GenerictracePackageImpl extends EPackageImpl implements Generictrac
 
 		initEClass(integerObjectAttributeValueEClass, IntegerObjectAttributeValue.class, "IntegerObjectAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getIntegerObjectAttributeValue_AttributeValue(), ecorePackage.getEIntegerObject(), "attributeValue", null, 0, 1, IntegerObjectAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(doubleAttributeValueEClass, DoubleAttributeValue.class, "DoubleAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getDoubleAttributeValue_AttributeValue(), ecorePackage.getEDouble(), "attributeValue", null, 0, 1, DoubleAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(manyDoubleAttributeValueEClass, ManyDoubleAttributeValue.class, "ManyDoubleAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getManyDoubleAttributeValue_AttributeValue(), ecorePackage.getEDouble(), "attributeValue", null, 0, -1, ManyDoubleAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(doubleObjectAttributeValueEClass, DoubleObjectAttributeValue.class, "DoubleObjectAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getDoubleObjectAttributeValue_AttributeValue(), ecorePackage.getEDoubleObject(), "attributeValue", null, 0, 1, DoubleObjectAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(longAttributeValueEClass, LongAttributeValue.class, "LongAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getLongAttributeValue_AttributeValue(), ecorePackage.getELong(), "attributeValue", null, 0, 1, LongAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(manyLongAttributeValueEClass, ManyLongAttributeValue.class, "ManyLongAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getManyLongAttributeValue_AttributeValue(), ecorePackage.getELong(), "attributeValue", null, 0, -1, ManyLongAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+		initEClass(longObjectAttributeValueEClass, LongObjectAttributeValue.class, "LongObjectAttributeValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getLongObjectAttributeValue_AttributeValue(), ecorePackage.getELongObject(), "attributeValue", null, 0, 1, LongObjectAttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		// Initialize data types
 		initEDataType(iSerializableEDataType, byte[].class, "ISerializable", IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS);

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/IntegerAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/IntegerAttributeValueImpl.java
@@ -162,7 +162,7 @@ public class IntegerAttributeValueImpl extends GenericAttributeValueImpl impleme
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (attributeValue: ");
 		result.append(attributeValue);
 		result.append(')');

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/IntegerObjectAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/IntegerObjectAttributeValueImpl.java
@@ -162,7 +162,7 @@ public class IntegerObjectAttributeValueImpl extends GenericAttributeValueImpl i
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (attributeValue: ");
 		result.append(attributeValue);
 		result.append(')');

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/LongAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/LongAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
 
 import org.eclipse.emf.common.notify.Notification;
 
@@ -21,46 +8,49 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Long Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.BooleanAttributeValueImpl#isAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class BooleanAttributeValueImpl extends GenericAttributeValueImpl implements BooleanAttributeValue {
+public class LongAttributeValueImpl extends GenericAttributeValueImpl implements LongAttributeValue {
 	/**
-	 * The default value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The default value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean ATTRIBUTE_VALUE_EDEFAULT = false;
+	protected static final long ATTRIBUTE_VALUE_EDEFAULT = 0L;
 
 	/**
-	 * The cached value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected boolean attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
+	protected long attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected BooleanAttributeValueImpl() {
+	protected LongAttributeValueImpl() {
 		super();
 	}
 
@@ -71,7 +61,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.BOOLEAN_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.LONG_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -79,7 +69,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isAttributeValue() {
+	public long getAttributeValue() {
 		return attributeValue;
 	}
 
@@ -88,11 +78,11 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setAttributeValue(boolean newAttributeValue) {
-		boolean oldAttributeValue = attributeValue;
+	public void setAttributeValue(long newAttributeValue) {
+		long oldAttributeValue = attributeValue;
 		attributeValue = newAttributeValue;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
+			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
 	}
 
 	/**
@@ -103,8 +93,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return isAttributeValue();
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -117,8 +107,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				setAttributeValue((Boolean)newValue);
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue((Long)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -132,7 +122,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				setAttributeValue(ATTRIBUTE_VALUE_EDEFAULT);
 				return;
 		}
@@ -147,7 +137,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return attributeValue != ATTRIBUTE_VALUE_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
@@ -169,4 +159,4 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 		return result.toString();
 	}
 
-} //BooleanAttributeValueImpl
+} //LongAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/LongObjectAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/LongObjectAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
 
 import org.eclipse.emf.common.notify.Notification;
 
@@ -21,46 +8,49 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Long Object Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.BooleanAttributeValueImpl#isAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.LongObjectAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class BooleanAttributeValueImpl extends GenericAttributeValueImpl implements BooleanAttributeValue {
+public class LongObjectAttributeValueImpl extends GenericAttributeValueImpl implements LongObjectAttributeValue {
 	/**
-	 * The default value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The default value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected static final boolean ATTRIBUTE_VALUE_EDEFAULT = false;
+	protected static final Long ATTRIBUTE_VALUE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #isAttributeValue() <em>Attribute Value</em>}' attribute.
+	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #isAttributeValue()
+	 * @see #getAttributeValue()
 	 * @generated
 	 * @ordered
 	 */
-	protected boolean attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
+	protected Long attributeValue = ATTRIBUTE_VALUE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected BooleanAttributeValueImpl() {
+	protected LongObjectAttributeValueImpl() {
 		super();
 	}
 
@@ -71,7 +61,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.BOOLEAN_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.LONG_OBJECT_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -79,7 +69,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isAttributeValue() {
+	public Long getAttributeValue() {
 		return attributeValue;
 	}
 
@@ -88,11 +78,11 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public void setAttributeValue(boolean newAttributeValue) {
-		boolean oldAttributeValue = attributeValue;
+	public void setAttributeValue(Long newAttributeValue) {
+		Long oldAttributeValue = attributeValue;
 		attributeValue = newAttributeValue;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
+			eNotify(new ENotificationImpl(this, Notification.SET, GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE, oldAttributeValue, attributeValue));
 	}
 
 	/**
@@ -103,8 +93,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return isAttributeValue();
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -117,8 +107,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				setAttributeValue((Boolean)newValue);
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				setAttributeValue((Long)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -132,7 +122,7 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				setAttributeValue(ATTRIBUTE_VALUE_EDEFAULT);
 				return;
 		}
@@ -147,8 +137,8 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.BOOLEAN_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
-				return attributeValue != ATTRIBUTE_VALUE_EDEFAULT;
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+				return ATTRIBUTE_VALUE_EDEFAULT == null ? attributeValue != null : !ATTRIBUTE_VALUE_EDEFAULT.equals(attributeValue);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -169,4 +159,4 @@ public class BooleanAttributeValueImpl extends GenericAttributeValueImpl impleme
 		return result.toString();
 	}
 
-} //BooleanAttributeValueImpl
+} //LongObjectAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyBooleanAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyBooleanAttributeValueImpl.java
@@ -147,7 +147,7 @@ public class ManyBooleanAttributeValueImpl extends GenericAttributeValueImpl imp
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (attributeValue: ");
 		result.append(attributeValue);
 		result.append(')');

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyDoubleAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyDoubleAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
-import org.eclipse.gemoc.trace.commons.model.generictrace.ManyIntegerAttributeValue;
 
 import java.util.Collection;
 
@@ -23,20 +10,23 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+import org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Many Integer Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Many Double Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyIntegerAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyDoubleAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl implements ManyIntegerAttributeValue {
+public class ManyDoubleAttributeValueImpl extends GenericAttributeValueImpl implements ManyDoubleAttributeValue {
 	/**
 	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute list.
 	 * <!-- begin-user-doc -->
@@ -45,14 +35,14 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 * @generated
 	 * @ordered
 	 */
-	protected EList<Integer> attributeValue;
+	protected EList<Double> attributeValue;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected ManyIntegerAttributeValueImpl() {
+	protected ManyDoubleAttributeValueImpl() {
 		super();
 	}
 
@@ -63,7 +53,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.MANY_INTEGER_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.MANY_DOUBLE_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -71,9 +61,9 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<Integer> getAttributeValue() {
+	public EList<Double> getAttributeValue() {
 		if (attributeValue == null) {
-			attributeValue = new EDataTypeUniqueEList<Integer>(Integer.class, this, GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+			attributeValue = new EDataTypeUniqueEList<Double>(Double.class, this, GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
 		}
 		return attributeValue;
 	}
@@ -86,7 +76,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -101,9 +91,9 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				getAttributeValue().clear();
-				getAttributeValue().addAll((Collection<? extends Integer>)newValue);
+				getAttributeValue().addAll((Collection<? extends Double>)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -117,7 +107,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				getAttributeValue().clear();
 				return;
 		}
@@ -132,7 +122,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return attributeValue != null && !attributeValue.isEmpty();
 		}
 		return super.eIsSet(featureID);
@@ -154,4 +144,4 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 		return result.toString();
 	}
 
-} //ManyIntegerAttributeValueImpl
+} //ManyDoubleAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyLongAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyLongAttributeValueImpl.java
@@ -1,19 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2017 Inria and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Inria - initial API and implementation
- *******************************************************************************/
 /**
  */
 package org.eclipse.gemoc.trace.commons.model.generictrace.impl;
-
-import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
-import org.eclipse.gemoc.trace.commons.model.generictrace.ManyIntegerAttributeValue;
 
 import java.util.Collection;
 
@@ -23,20 +10,23 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictracePackage;
+import org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue;
+
 /**
  * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Many Integer Attribute Value</b></em>'.
+ * An implementation of the model object '<em><b>Many Long Attribute Value</b></em>'.
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * </p>
  * <ul>
- *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyIntegerAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
+ *   <li>{@link org.eclipse.gemoc.trace.commons.model.generictrace.impl.ManyLongAttributeValueImpl#getAttributeValue <em>Attribute Value</em>}</li>
  * </ul>
  *
  * @generated
  */
-public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl implements ManyIntegerAttributeValue {
+public class ManyLongAttributeValueImpl extends GenericAttributeValueImpl implements ManyLongAttributeValue {
 	/**
 	 * The cached value of the '{@link #getAttributeValue() <em>Attribute Value</em>}' attribute list.
 	 * <!-- begin-user-doc -->
@@ -45,14 +35,14 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 * @generated
 	 * @ordered
 	 */
-	protected EList<Integer> attributeValue;
+	protected EList<Long> attributeValue;
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	protected ManyIntegerAttributeValueImpl() {
+	protected ManyLongAttributeValueImpl() {
 		super();
 	}
 
@@ -63,7 +53,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 */
 	@Override
 	protected EClass eStaticClass() {
-		return GenerictracePackage.Literals.MANY_INTEGER_ATTRIBUTE_VALUE;
+		return GenerictracePackage.Literals.MANY_LONG_ATTRIBUTE_VALUE;
 	}
 
 	/**
@@ -71,9 +61,9 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EList<Integer> getAttributeValue() {
+	public EList<Long> getAttributeValue() {
 		if (attributeValue == null) {
-			attributeValue = new EDataTypeUniqueEList<Integer>(Integer.class, this, GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
+			attributeValue = new EDataTypeUniqueEList<Long>(Long.class, this, GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE);
 		}
 		return attributeValue;
 	}
@@ -86,7 +76,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return getAttributeValue();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -101,9 +91,9 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				getAttributeValue().clear();
-				getAttributeValue().addAll((Collection<? extends Integer>)newValue);
+				getAttributeValue().addAll((Collection<? extends Long>)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -117,7 +107,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				getAttributeValue().clear();
 				return;
 		}
@@ -132,7 +122,7 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case GenerictracePackage.MANY_INTEGER_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE__ATTRIBUTE_VALUE:
 				return attributeValue != null && !attributeValue.isEmpty();
 		}
 		return super.eIsSet(featureID);
@@ -154,4 +144,4 @@ public class ManyIntegerAttributeValueImpl extends GenericAttributeValueImpl imp
 		return result.toString();
 	}
 
-} //ManyIntegerAttributeValueImpl
+} //ManyLongAttributeValueImpl

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyStringAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/ManyStringAttributeValueImpl.java
@@ -147,7 +147,7 @@ public class ManyStringAttributeValueImpl extends GenericAttributeValueImpl impl
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (attributeValue: ");
 		result.append(attributeValue);
 		result.append(')');

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/StringAttributeValueImpl.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/impl/StringAttributeValueImpl.java
@@ -162,7 +162,7 @@ public class StringAttributeValueImpl extends GenericAttributeValueImpl implemen
 	public String toString() {
 		if (eIsProxy()) return super.toString();
 
-		StringBuffer result = new StringBuffer(super.toString());
+		StringBuilder result = new StringBuilder(super.toString());
 		result.append(" (attributeValue: ");
 		result.append(attributeValue);
 		result.append(')');

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/util/GenerictraceAdapterFactory.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/util/GenerictraceAdapterFactory.java
@@ -169,6 +169,30 @@ public class GenerictraceAdapterFactory extends AdapterFactoryImpl {
 				return createIntegerObjectAttributeValueAdapter();
 			}
 			@Override
+			public Adapter caseDoubleAttributeValue(DoubleAttributeValue object) {
+				return createDoubleAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseManyDoubleAttributeValue(ManyDoubleAttributeValue object) {
+				return createManyDoubleAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseDoubleObjectAttributeValue(DoubleObjectAttributeValue object) {
+				return createDoubleObjectAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseLongAttributeValue(LongAttributeValue object) {
+				return createLongAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseManyLongAttributeValue(ManyLongAttributeValue object) {
+				return createManyLongAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseLongObjectAttributeValue(LongObjectAttributeValue object) {
+				return createLongObjectAttributeValueAdapter();
+			}
+			@Override
 			public <StateSubType extends State<?, ?>> Adapter caseStep(Step<StateSubType> object) {
 				return createStepAdapter();
 			}
@@ -505,6 +529,90 @@ public class GenerictraceAdapterFactory extends AdapterFactoryImpl {
 	 * @generated
 	 */
 	public Adapter createIntegerObjectAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue <em>Double Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue
+	 * @generated
+	 */
+	public Adapter createDoubleAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue <em>Many Double Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyDoubleAttributeValue
+	 * @generated
+	 */
+	public Adapter createManyDoubleAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue <em>Double Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue
+	 * @generated
+	 */
+	public Adapter createDoubleObjectAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue <em>Long Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue
+	 * @generated
+	 */
+	public Adapter createLongAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue <em>Many Long Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.ManyLongAttributeValue
+	 * @generated
+	 */
+	public Adapter createManyLongAttributeValueAdapter() {
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue <em>Long Object Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue
+	 * @generated
+	 */
+	public Adapter createLongObjectAttributeValueAdapter() {
 		return null;
 	}
 

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/util/GenerictraceSwitch.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model/src/org/eclipse/gemoc/trace/commons/model/generictrace/util/GenerictraceSwitch.java
@@ -255,6 +255,60 @@ public class GenerictraceSwitch<T> extends Switch<T> {
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case GenerictracePackage.DOUBLE_ATTRIBUTE_VALUE: {
+				DoubleAttributeValue doubleAttributeValue = (DoubleAttributeValue)theEObject;
+				T result = caseDoubleAttributeValue(doubleAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(doubleAttributeValue);
+				if (result == null) result = caseGenericValue(doubleAttributeValue);
+				if (result == null) result = caseValue(doubleAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case GenerictracePackage.MANY_DOUBLE_ATTRIBUTE_VALUE: {
+				ManyDoubleAttributeValue manyDoubleAttributeValue = (ManyDoubleAttributeValue)theEObject;
+				T result = caseManyDoubleAttributeValue(manyDoubleAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(manyDoubleAttributeValue);
+				if (result == null) result = caseGenericValue(manyDoubleAttributeValue);
+				if (result == null) result = caseValue(manyDoubleAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case GenerictracePackage.DOUBLE_OBJECT_ATTRIBUTE_VALUE: {
+				DoubleObjectAttributeValue doubleObjectAttributeValue = (DoubleObjectAttributeValue)theEObject;
+				T result = caseDoubleObjectAttributeValue(doubleObjectAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(doubleObjectAttributeValue);
+				if (result == null) result = caseGenericValue(doubleObjectAttributeValue);
+				if (result == null) result = caseValue(doubleObjectAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case GenerictracePackage.LONG_ATTRIBUTE_VALUE: {
+				LongAttributeValue longAttributeValue = (LongAttributeValue)theEObject;
+				T result = caseLongAttributeValue(longAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(longAttributeValue);
+				if (result == null) result = caseGenericValue(longAttributeValue);
+				if (result == null) result = caseValue(longAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case GenerictracePackage.MANY_LONG_ATTRIBUTE_VALUE: {
+				ManyLongAttributeValue manyLongAttributeValue = (ManyLongAttributeValue)theEObject;
+				T result = caseManyLongAttributeValue(manyLongAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(manyLongAttributeValue);
+				if (result == null) result = caseGenericValue(manyLongAttributeValue);
+				if (result == null) result = caseValue(manyLongAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case GenerictracePackage.LONG_OBJECT_ATTRIBUTE_VALUE: {
+				LongObjectAttributeValue longObjectAttributeValue = (LongObjectAttributeValue)theEObject;
+				T result = caseLongObjectAttributeValue(longObjectAttributeValue);
+				if (result == null) result = caseGenericAttributeValue(longObjectAttributeValue);
+				if (result == null) result = caseGenericValue(longObjectAttributeValue);
+				if (result == null) result = caseValue(longObjectAttributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			default: return defaultCase(theEObject);
 		}
 	}
@@ -556,6 +610,96 @@ public class GenerictraceSwitch<T> extends Switch<T> {
 	 * @generated
 	 */
 	public T caseIntegerObjectAttributeValue(IntegerObjectAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Double Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Double Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseDoubleAttributeValue(DoubleAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Many Double Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Many Double Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseManyDoubleAttributeValue(ManyDoubleAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Double Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Double Object Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseDoubleObjectAttributeValue(DoubleObjectAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Long Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Long Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseLongAttributeValue(LongAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Many Long Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Many Long Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseManyLongAttributeValue(ManyLongAttributeValue object) {
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>Long Object Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Long Object Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseLongObjectAttributeValue(LongObjectAttributeValue object) {
 		return null;
 	}
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/META-INF/MANIFEST.MF
@@ -19,4 +19,5 @@ Export-Package: org.eclipse.gemoc.trace.gemoc.traceaddon
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.gemoc.executionframework.debugger
 Automatic-Module-Name: org.eclipse.gemoc.trace.gemoc
+Bundle-Activator: org.eclipse.gemoc.trace.gemoc.Activator
 

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/Activator.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/Activator.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.trace.gemoc;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ */
+public class Activator implements BundleActivator {
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.eclipse.gemoc.execution.sequential.javaengine"; //$NON-NLS-1$
+	
+	private static BundleContext context;
+
+	static BundleContext getContext() {
+		return context;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
+	 */
+	public void start(BundleContext bundleContext) throws Exception {
+		Activator.context = bundleContext;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext bundleContext) throws Exception {
+		Activator.context = null;
+	}
+
+	public static void warn(String msg, Throwable e){
+		Platform.getLog(Platform.getBundle(PLUGIN_ID)).log(new Status(Status.WARNING, PLUGIN_ID,
+                Status.OK, 
+                msg, 
+                e));
+	}
+	public static void error(String msg, Throwable e){
+		Platform.getLog(Platform.getBundle(PLUGIN_ID)).log(new Status(Status.ERROR, PLUGIN_ID,
+                Status.OK, 
+                msg, 
+                e));
+	}
+}

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
@@ -47,15 +47,15 @@ import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonS
 
 abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTraceAddon<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> {
 
-	private IExecutionContext<?, ?, ?> _executionContext
-	private ITraceExplorer<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExplorer
-	private ITraceExtractor<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExtractor
-	private ITraceConstructor traceConstructor
-	private ITraceNotifier traceNotifier
-	private BatchModelChangeListener traceListener
-	private var boolean needTransaction = true
-	private BatchModelChangeListener listenerAddon
-	private Trace<Step<?>, TracedObject<?>, State<?, ?>> trace
+	IExecutionContext<?, ?, ?> _executionContext
+	ITraceExplorer<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExplorer
+	ITraceExtractor<Step<?>, State<?, ?>, TracedObject<?>, Dimension<?>, Value<?>> traceExtractor
+	ITraceConstructor traceConstructor
+	ITraceNotifier traceNotifier
+	BatchModelChangeListener traceListener
+	var boolean needTransaction = true
+	BatchModelChangeListener listenerAddon
+	Trace<Step<?>, TracedObject<?>, State<?, ?>> trace
 
 	protected abstract def ITraceConstructor constructTraceConstructor(Resource modelResource, Resource traceResource,
 		Map<EObject, TracedObject<?>> exeToTraced)
@@ -79,7 +79,7 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 		return traceNotifier
 	}
 
-	public override void load(Resource traceResource) {
+	override void load(Resource traceResource) {
 		val root = traceResource.contents.head
 		if (root instanceof Trace<?, ?, ?>) {
 			trace = root as Trace<Step<?>, TracedObject<?>, State<?, ?>>

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
@@ -22,10 +22,8 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
-import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.MutableField;
 import org.eclipse.gemoc.executionframework.engine.core.CommandExecution;
-
 import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericDimension;

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
@@ -40,6 +40,8 @@ import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.MutableField;
 import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericDimension;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericSequentialStep;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericSmallStep;
@@ -50,6 +52,8 @@ import org.eclipse.gemoc.trace.commons.model.generictrace.GenericValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictraceFactory;
 import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerObjectAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.SingleReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.StringAttributeValue;
@@ -59,6 +63,7 @@ import org.eclipse.gemoc.trace.commons.model.trace.MSEModel;
 import org.eclipse.gemoc.trace.commons.model.trace.Step;
 import org.eclipse.gemoc.trace.commons.model.trace.Trace;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;
+import org.eclipse.gemoc.trace.gemoc.Activator;
 import org.eclipse.gemoc.trace.gemoc.api.ITraceConstructor;
 
 public class GenericTraceConstructor implements ITraceConstructor {
@@ -131,6 +136,34 @@ public class GenericTraceConstructor implements ITraceConstructor {
 					value.setAttributeValue((Integer)dynamicProperty.get().getValue());
 				}
 				result = value;
+			} else if (eType == EcorePackage.Literals.EDOUBLE) {
+				final DoubleAttributeValue value = GenerictraceFactory.eINSTANCE.createDoubleAttributeValue();
+				if(dynamicProperty.isPresent()) {
+					value.setAttributeValue((Double)dynamicProperty.get().getValue());
+				}
+				result = value;
+			} else if (eType == EcorePackage.Literals.EDOUBLE_OBJECT) {
+				final DoubleObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createDoubleObjectAttributeValue();
+				if(dynamicProperty.isPresent()) {
+					value.setAttributeValue((Double)dynamicProperty.get().getValue());
+				}
+				result = value;
+			} else if (eType == EcorePackage.Literals.ELONG) {
+				final LongAttributeValue value = GenerictraceFactory.eINSTANCE.createLongAttributeValue();
+				if(dynamicProperty.isPresent()) {
+					value.setAttributeValue((Long)dynamicProperty.get().getValue());
+				}
+				result = value;
+			} else if (eType == EcorePackage.Literals.ELONG_OBJECT) {
+				final LongObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createLongObjectAttributeValue();
+				if(dynamicProperty.isPresent()) {
+					value.setAttributeValue((Long)dynamicProperty.get().getValue());
+				}
+				result = value;
+			} else {
+				Activator.error("eType "+eType+" not supported yet (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n "
+						+ "Please use another type in your RTD or consider to contribute to GEMOC framework", 
+						new java.lang.UnsupportedOperationException("eType "+eType+" not supported yet (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
 			}
 		} else if (mutableProperty instanceof EReference) {
 			if (mutableProperty.isMany()) {
@@ -200,6 +233,40 @@ public class GenericTraceConstructor implements ITraceConstructor {
 							value.setAttributeValue((String)dynamicProperty.get().getValue());
 						}
 						firstValue = value;
+					} else if (eType == EcorePackage.Literals.EDOUBLE) {
+						final DoubleAttributeValue value = GenerictraceFactory.eINSTANCE.createDoubleAttributeValue();
+						if(dynamicProperty.isPresent()) {
+							value.setAttributeValue((Double)dynamicProperty.get().getValue());
+						}
+						firstValue = value; 
+					} else if (eType == EcorePackage.Literals.ELONG) {
+						final LongAttributeValue value = GenerictraceFactory.eINSTANCE.createLongAttributeValue();
+						if(dynamicProperty.isPresent()) {
+							value.setAttributeValue((Long)dynamicProperty.get().getValue());
+						}
+						firstValue = value;
+					} else if (eType == EcorePackage.Literals.EINTEGER_OBJECT) {
+						final IntegerObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createIntegerObjectAttributeValue();
+						if(dynamicProperty.isPresent()) {
+							value.setAttributeValue((Integer)dynamicProperty.get().getValue());
+						}
+						firstValue = value;
+					} else if (eType == EcorePackage.Literals.EDOUBLE_OBJECT) {
+						final DoubleObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createDoubleObjectAttributeValue();
+						if(dynamicProperty.isPresent()) {
+							value.setAttributeValue((Double)dynamicProperty.get().getValue());
+						}
+						firstValue = value;
+					} else if (eType == EcorePackage.Literals.ELONG_OBJECT) {
+						final LongObjectAttributeValue value = GenerictraceFactory.eINSTANCE.createLongObjectAttributeValue();
+						if(dynamicProperty.isPresent()) {
+							value.setAttributeValue((Long)dynamicProperty.get().getValue());
+						}
+						firstValue = value;
+					} else {
+						Activator.error("eType "+eType+" not supported yet (used by "+mutableProperty.getName()+" of "+object.eClass()+ "); "
+								+ "Please use another type in your RTD or consider to contribute to GEMOC framework", 
+								new java.lang.UnsupportedOperationException("eType "+eType+" not supported yet (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
 					}
 				} else if (mutableProperty instanceof EReference) {
 					if (mutableProperty.isMany()) {
@@ -210,7 +277,13 @@ public class GenericTraceConstructor implements ITraceConstructor {
 						final ManyReferenceValue value = GenerictraceFactory.eINSTANCE.createManyReferenceValue();
 						for (EObject o : modelElements) {
 							addNewObjectToStateIfDynamic(o, state);
-							value.getReferenceValues().add(exeToTraced.get(o));
+							final TracedObject<?> tracedObj = exeToTraced.get(o);
+							if(tracedObj == null) {
+							Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
+									+ "Did you correctly declare it as Runtime Data ?", 
+									new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+							}
+							value.getReferenceValues().add(tracedObj);
 						}
 						firstValue = value;
 					} else {

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
@@ -23,21 +23,13 @@ import java.util.stream.Collectors;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
-import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.ModelChange;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.NewObjectModelChange;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.NonCollectionFieldModelChange;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.PotentialCollectionFieldModelChange;
-import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.RemovedObjectModelChange;
-import org.eclipse.gemoc.xdsmlframework.commons.DynamicAnnotationHelper;
 import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
-import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.executionframework.debugger.MutableField;
 import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue;
@@ -65,6 +57,11 @@ import org.eclipse.gemoc.trace.commons.model.trace.Trace;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;
 import org.eclipse.gemoc.trace.gemoc.Activator;
 import org.eclipse.gemoc.trace.gemoc.api.ITraceConstructor;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.ModelChange;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.NewObjectModelChange;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.NonCollectionFieldModelChange;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.PotentialCollectionFieldModelChange;
+import org.eclipse.gemoc.xdsmlframework.api.engine_addon.modelchangelistener.RemovedObjectModelChange;
 
 public class GenericTraceConstructor implements ITraceConstructor {
 
@@ -94,7 +91,6 @@ public class GenericTraceConstructor implements ITraceConstructor {
 	}
 
 	private boolean addNewObjectToStateIfDynamic(EObject object, GenericState state) {
-		final EClass c = object.eClass();
 		List<MutableField> fields = dynamicPartAccessor.extractMutableField(object);
 		final List<EStructuralFeature> mutableProperties = fields.stream()
 				.map(f -> f.getMutableProperty())

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
@@ -170,7 +170,13 @@ public class GenericTraceConstructor implements ITraceConstructor {
 				final ManyReferenceValue value = GenerictraceFactory.eINSTANCE.createManyReferenceValue();
 				for (EObject o : modelElements) {
 					if (dynamicPartAccessor.isDynamic(o) || !fields.isEmpty()) {
-						value.getReferenceValues().add(exeToTraced.get(o));
+						final TracedObject<?> tracedObj = exeToTraced.get(o);
+						if(tracedObj == null) {
+						Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
+								+ "Did you correctly declare it as Runtime Data ?", 
+								new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+						}
+						value.getReferenceValues().add(tracedObj);
 					} else {
 						value.getReferenceValues().add(o);
 					}
@@ -183,7 +189,13 @@ public class GenericTraceConstructor implements ITraceConstructor {
 				}
 				final SingleReferenceValue value = GenerictraceFactory.eINSTANCE.createSingleReferenceValue();
 				if (o != null  && dynamicPartAccessor.isDynamic(o)) {
-					value.setReferenceValue(exeToTraced.get(o));
+					final TracedObject<?> tracedObj = exeToTraced.get(o);
+					if(tracedObj == null) {
+					Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
+							+ "Did you correctly declare it as Runtime Data ?", 
+							new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+					} 
+					value.setReferenceValue(tracedObj);
 				} else {
 					value.setReferenceValue(o);
 				}
@@ -290,7 +302,13 @@ public class GenericTraceConstructor implements ITraceConstructor {
 						if (o != null) {
 							addNewObjectToStateIfDynamic(o, state);
 							final SingleReferenceValue value = GenerictraceFactory.eINSTANCE.createSingleReferenceValue();
-							value.setReferenceValue(exeToTraced.get(o));
+							final TracedObject<?> tracedObj = exeToTraced.get(o);
+							if(tracedObj == null) {
+							Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
+									+ "Did you correctly declare it as Runtime Data ?", 
+									new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+							}
+							value.setReferenceValue(tracedObj);
 							firstValue = value;
 						}
 					}

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceEngineAddon.java
@@ -16,7 +16,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.gemoc.executionframework.debugger.DefaultDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
-import org.eclipse.gemoc.executionframework.debugger.IMutableFieldExtractor;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
 import org.eclipse.gemoc.trace.commons.model.trace.Trace;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;


### PR DESCRIPTION
This PR  implements some missing eType in generic trace and improve user feedback in case of trouble in the RTD definition.

- Implemented missing eTypes: EDouble, EDoubleObject, ELong and ELongObject
- User feedback in case of trouble in the RTD definition is reported in the error log with a clear message inviting the language designer to declare as Runtime Data a precise attribute/reference.

This PR contributes to #83 and #85