### PR TITLE
Add command line Eclipse application to run GEMOC languages and headless product

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/Activator.java
@@ -39,41 +39,43 @@ public class Activator extends AbstractUIPlugin {
 	 * The constructor
 	 */
 	public Activator() {
-		IWorkbench workbench = PlatformUI.getWorkbench();
-		//final IWorkbenchPage activePage = workbench.getActiveWorkbenchWindow().getActivePage();
-		workbench.addWorkbenchListener(new IWorkbenchListener() {
-			public boolean preShutdown(IWorkbench workbench, boolean forced) {
-				
-				// close all editors (a bit too strong ;-)  )
-				// activePage.closeEditors(activePage.getEditorReferences(), false);
-				
-				// try to close only Sirius sessions related to engines
-				for (Entry<String, IExecutionEngine<?>> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet())
-			    {	
-					try{
-						// stop any running engine
-						IExecutionEngine<?> engine = engineEntry.getValue();
-						if(engine.getRunningStatus() != RunStatus.Stopped){
+		if(PlatformUI.isWorkbenchRunning()) { // if running in headless, the workbench does not exit
+			IWorkbench workbench = PlatformUI.getWorkbench();
+			//final IWorkbenchPage activePage = workbench.getActiveWorkbenchWindow().getActivePage();
+			workbench.addWorkbenchListener(new IWorkbenchListener() {
+				public boolean preShutdown(IWorkbench workbench, boolean forced) {
+					
+					// close all editors (a bit too strong ;-)  )
+					// activePage.closeEditors(activePage.getEditorReferences(), false);
+					
+					// try to close only Sirius sessions related to engines
+					for (Entry<String, IExecutionEngine<?>> engineEntry : org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry.getRunningEngines().entrySet())
+				    {	
+						try{
+							// stop any running engine
+							IExecutionEngine<?> engine = engineEntry.getValue();
+							if(engine.getRunningStatus() != RunStatus.Stopped){
+								
+								engine.dispose();
+							}
 							
-							engine.dispose();
-						}
-						
-						// ensure to clear sirius session
-						URI uri = engine.getExecutionContext().getRunConfiguration().getAnimatorURI();
-						if (uri != null) {
-							Session session = SessionManager.INSTANCE.getSession(uri, new NullProgressMonitor());
-							session.close(new NullProgressMonitor());
-							SessionManager.INSTANCE.remove(session);
-						}
-							
-					} catch (Exception e){ /* we don't care try the other */}
-		    	}
-				
-				return true;
-			}
-			public void postShutdown(IWorkbench workbench) {
-			}
-		}); 
+							// ensure to clear sirius session
+							URI uri = engine.getExecutionContext().getRunConfiguration().getAnimatorURI();
+							if (uri != null) {
+								Session session = SessionManager.INSTANCE.getSession(uri, new NullProgressMonitor());
+								session.close(new NullProgressMonitor());
+								SessionManager.INSTANCE.remove(session);
+							}
+								
+						} catch (Exception e){ /* we don't care try the other */}
+			    	}
+					
+					return true;
+				}
+				public void postShutdown(IWorkbench workbench) {
+				}
+			}); 
+		}
 	}
 
 	/*

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
@@ -16,6 +16,7 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystem;
 import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
+import org.eclipse.gemoc.execution.sequential.javaengine.IK3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.K3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
 import org.eclipse.gemoc.execution.sequential.javaengine.SequentialModelExecutionContext;
@@ -25,16 +26,16 @@ import org.eclipse.gemoc.executionframework.engine.ui.launcher.AbstractSequentia
 import org.eclipse.gemoc.executionframework.ui.views.engine.EnginesStatusView;
 import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
 
-public class Launcher extends AbstractSequentialGemocLauncher<SequentialModelExecutionContext<K3RunConfiguration>, K3RunConfiguration> {
+public class Launcher extends AbstractSequentialGemocLauncher<SequentialModelExecutionContext<IK3RunConfiguration>, IK3RunConfiguration> {
 
 	public final static String TYPE_ID = Activator.PLUGIN_ID + ".launcher";
 
 	@Override
-	protected PlainK3ExecutionEngine createExecutionEngine(K3RunConfiguration runConfiguration,
+	protected PlainK3ExecutionEngine createExecutionEngine(IK3RunConfiguration runConfiguration,
 			ExecutionMode executionMode) throws CoreException, EngineContextException {
 		// create and initialize engine
 		PlainK3ExecutionEngine executionEngine = new PlainK3ExecutionEngine();
-		SequentialModelExecutionContext<K3RunConfiguration> executioncontext = new SequentialModelExecutionContext<K3RunConfiguration>(
+		SequentialModelExecutionContext<IK3RunConfiguration> executioncontext = new SequentialModelExecutionContext<IK3RunConfiguration>(
 				runConfiguration, executionMode);
 		executioncontext.getExecutionPlatform().getModelLoader().setProgressMonitor(this.launchProgressMonitor);
 		executioncontext.initializeResourceModel();

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Gemoc Sequential Language Api
 Bundle-SymbolicName: org.eclipse.gemoc.execution.sequential.javaengine;singleton:=true
 Bundle-Version: 4.0.0.qualifier
-Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
- org.eclipse.gemoc.execution.sequential.javaxdsml.api,
+Require-Bundle: org.eclipse.gemoc.xdsmlframework.api;visibility:=reexport,
+ org.eclipse.gemoc.execution.sequential.javaxdsml.api;visibility:=reexport,
  org.eclipse.gemoc.executionframework.engine,
  fr.inria.diverse.k3.al.annotationprocessor.plugin,
  org.eclipse.jdt.core,
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.trace.commons.model;bundle-version="0.1.0",
  org.eclipse.gemoc.trace.commons;bundle-version="1.0.0",
  org.eclipse.debug.core,
- org.eclipse.gemoc.trace.gemoc.api;bundle-version="3.0.0"
+ org.eclipse.gemoc.trace.gemoc.api;bundle-version="3.0.0";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine
 Bundle-Activator: org.eclipse.gemoc.execution.sequential.javaengine.Activator

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -52,7 +52,7 @@ import fr.inria.diverse.melange.adapters.EObjectAdapter;
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
-public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine<SequentialModelExecutionContext<K3RunConfiguration>, K3RunConfiguration>
+public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine<SequentialModelExecutionContext<IK3RunConfiguration>, IK3RunConfiguration>
 		implements IStepManager {
 
 	private Method initializeMethod;
@@ -74,7 +74,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * operation.
 	 */
 	@Override
-	protected void prepareEntryPoint(SequentialModelExecutionContext<K3RunConfiguration> executionContext) {
+	protected void prepareEntryPoint(SequentialModelExecutionContext<IK3RunConfiguration> executionContext) {
 		/*
 		 * Get info from the RunConfiguration
 		 */
@@ -128,7 +128,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	}
 
 	@Override
-	protected void prepareInitializeModel(SequentialModelExecutionContext<K3RunConfiguration> executionContext) {
+	protected void prepareInitializeModel(SequentialModelExecutionContext<IK3RunConfiguration> executionContext) {
 
 		// try to get the initializeModelRunnable
 		String modelInitializationMethodQName = executionContext.getRunConfiguration().getModelInitializationMethod();
@@ -318,7 +318,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * 
 	 * Return null if not found.
 	 */
-	private Bundle findBundle(final SequentialModelExecutionContext<K3RunConfiguration> executionContext, String aspectClassName) {
+	private Bundle findBundle(final SequentialModelExecutionContext<IK3RunConfiguration> executionContext, String aspectClassName) {
 
 		// Look using JavaWorkspaceScope as this is safer and will look in
 		// dependencies


### PR DESCRIPTION
This PR is a complement of https://github.com/eclipse/gemoc-studio/pull/138 in order to enable the use in headless mode (ie. without UI) and clean some dependencies.

