### PR TITLE
Add restoreState support for missing eType

### DIFF
--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericStateManager.java
@@ -25,16 +25,22 @@ import org.eclipse.gemoc.executionframework.debugger.IDynamicPartAccessor;
 import org.eclipse.gemoc.executionframework.debugger.MutableField;
 import org.eclipse.gemoc.executionframework.engine.core.CommandExecution;
 import org.eclipse.gemoc.trace.commons.model.generictrace.BooleanAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.DoubleObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericDimension;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericState;
 import org.eclipse.gemoc.trace.commons.model.generictrace.GenericTracedObject;
 import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.IntegerObjectAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongAttributeValue;
+import org.eclipse.gemoc.trace.commons.model.generictrace.LongObjectAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.ManyReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.SingleReferenceValue;
 import org.eclipse.gemoc.trace.commons.model.generictrace.StringAttributeValue;
 import org.eclipse.gemoc.trace.commons.model.trace.State;
 import org.eclipse.gemoc.trace.commons.model.trace.TracedObject;
+import org.eclipse.gemoc.trace.gemoc.Activator;
 import org.eclipse.gemoc.trace.gemoc.api.IStateManager;
 
 public class GenericStateManager implements IStateManager<State<?, ?>> {
@@ -88,8 +94,23 @@ public class GenericStateManager implements IStateManager<State<?, ?>> {
 						dynamicProperty.get().setValue(((IntegerAttributeValue) v).getAttributeValue());
 					} else if (v instanceof BooleanAttributeValue) {
 						dynamicProperty.get().setValue(((BooleanAttributeValue) v).isAttributeValue());
-					} else {
+					} else if( v instanceof StringAttributeValue){
 						dynamicProperty.get().setValue(((StringAttributeValue) v).getAttributeValue());
+					} else if( v instanceof DoubleAttributeValue){
+						dynamicProperty.get().setValue(((DoubleAttributeValue) v).getAttributeValue());
+					} else if( v instanceof LongAttributeValue){
+						dynamicProperty.get().setValue(((LongAttributeValue) v).getAttributeValue());
+					} else	if (v instanceof IntegerObjectAttributeValue) {
+							dynamicProperty.get().setValue(((IntegerObjectAttributeValue) v).getAttributeValue());
+					} else if( v instanceof DoubleObjectAttributeValue){
+						dynamicProperty.get().setValue(((DoubleObjectAttributeValue) v).getAttributeValue());
+					} else if( v instanceof LongObjectAttributeValue){
+						dynamicProperty.get().setValue(((LongObjectAttributeValue) v).getAttributeValue());
+					} else {
+						//v.eContainingFeature()
+						Activator.error("eType "+v.eClass().getName()+" not supported yet (used by "+v.eContainingFeature().getName()+" of "+v.eContainingFeature().eContainer()+ ");\n "
+								+ "Please use another type in your RTD or consider to contribute to GEMOC framework", 
+								new java.lang.UnsupportedOperationException("eType "+v.eClass().getName()+" not supported yet (used by "+v.eContainingFeature().getName()+" of "+v.eContainingFeature().eContainer()+ ")"));
 					}
 				} else if (v instanceof SingleReferenceValue) {
 						final EObject refVal = ((SingleReferenceValue) v).getReferenceValue();


### PR DESCRIPTION
- complement to
https://github.com/eclipse/gemoc-studio-modeldebugging/pull/89
in order to deal with EDouble, ELong, EDoubleObject,ELongObject during the restoreState action

- also report cleaner error message when using unsupported type

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>