### PR TITLE
Add concurrent engine to the studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ This repository is part of a serie of repositories related to [GEMOC Studio](htt
 - https://github.com/eclipse/gemoc-studio
 - https://github.com/eclipse/gemoc-studio-modeldebugging
 - https://github.com/eclipse/gemoc-studio-execution-ale
+- https://github.com/eclipse/gemoc-studio-execution-java
+- https://github.com/eclipse/gemoc-studio-execution-moccml
+- https://github.com/eclipse/gemoc-studio-moccml
 -------------
 
 # ModelDebugging


### PR DESCRIPTION
This PR adds the build support and deployment of the concurrent engine in the studio.

cf. https://github.com/eclipse/gemoc-studio/issues/146
It comes with several PR in other repositories:
* https://github.com/eclipse/gemoc-studio-moccml/pull/1
* https://github.com/eclipse/gemoc-studio-execution-moccml/pull/1
* https://github.com/eclipse/gemoc-studio-execution-ale/pull/8
* https://github.com/eclipse/gemoc-studio/pull/148