### PR TITLE
[test] Adapt test helper code to latest api changes

### DIFF
--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: com.google.guava,
  org.eclipse.swt;bundle-version="3.105.3",
  org.eclipse.ui;bundle-version="3.108.1",
  org.eclipse.gemoc.trace.gemoc;bundle-version="2.4.0",
- org.eclipse.gemoc.executionframework.engine;bundle-version="2.4.0"
+ org.eclipse.gemoc.executionframework.engine;bundle-version="2.4.0",
+ org.eclipse.gemoc.execution.sequential.javaengine;bundle-version="4.0.0"
 Export-Package: org.eclipse.gemoc.executionframework.test.lib,
  org.eclipse.gemoc.executionframework.test.lib.impl
 Automatic-Module-Name: org.eclipse.gemoc.executionframework.test.lib

--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestEngineAddon.xtend
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestEngineAddon.xtend
@@ -42,7 +42,7 @@ class TestEngineAddon extends DefaultEngineAddon {
 		testResult.engineStopped = true
 	}
 
-	override stepExecuted(IExecutionEngine engine, Step<?> stepExecuted) {
+	override stepExecuted(IExecutionEngine<?> engine, Step<?> stepExecuted) {
 		testResult.amountOfStepsExecuted++
 		if (shouldStopAfter != -1 && shouldStopAfter < testResult.amountOfStepsExecuted) {
 			engine.stop

--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestHelper.xtend
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestHelper.xtend
@@ -109,7 +109,7 @@ class TestHelper {
 		val traceAddon = new GenericTraceEngineAddon()
 		val testResult = testWithJob(engine, language, #{}, #{traceAddon}, model, cleanup)
 		// TODO when other PR is merged
-		//testResult.trace = traceAddon.trace
+		testResult.trace = traceAddon.trace
 		return testResult
 	}
 

--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestRunConfiguration.xtend
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestRunConfiguration.xtend
@@ -12,8 +12,9 @@ import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtensionPoint
 import org.eclipse.gemoc.executionframework.test.lib.IExecutableModel
+import org.eclipse.gemoc.execution.sequential.javaengine.IK3RunConfiguration
 
-class TestRunConfiguration implements IRunConfiguration {
+class TestRunConfiguration implements IK3RunConfiguration {
 	private val ILanguageWrapper language
 	private val IExecutableModel model
 	private val Set<String> addonsToLoad
@@ -32,10 +33,6 @@ class TestRunConfiguration implements IRunConfiguration {
 
 	override getAnimatorURI() {
 		return null;
-	}
-
-	override getDeadlockDetectionDepth() {
-		return 0;
 	}
 
 	override getEngineAddonExtensions() {

--- a/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestUtil.xtend
+++ b/framework/execution_framework/tests/org.eclipse.gemoc.executionframework.test.lib/src/org/eclipse/gemoc/executionframework/test/lib/impl/TestUtil.xtend
@@ -114,7 +114,7 @@ class TestUtil {
 
 	def static public void removeStoppedEngines() {
 		val registry = Activator.getDefault().gemocRunningEngineRegistry
-		for (Entry<String, IExecutionEngine> engineEntry : registry.getRunningEngines().entrySet()) {
+		for (Entry<String, IExecutionEngine<?>> engineEntry : registry.getRunningEngines().entrySet()) {
 			if (engineEntry.value.runningStatus.equals(EngineStatus.RunStatus.Stopped)) {
 				registry.unregisterEngine(engineEntry.getKey())
 			}

--- a/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/META-INF/MANIFEST.MF
+++ b/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: com.google.guava,
  org.junit;bundle-version="4.12.0",
  org.eclipse.gemoc.executionframework.engine;bundle-version="2.4.0",
  org.eclipse.gemoc.xdsmlframework.api;bundle-version="2.4.0",
- fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="3.2.1"
+ fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="3.2.1",
+ org.eclipse.emf.transaction;bundle-version="1.9.1"
 Export-Package: org.eclipse.gemoc.execution.sequential.javaengine.tests,
  org.eclipse.gemoc.execution.sequential.javaengine.tests.languages,
  org.eclipse.gemoc.execution.sequential.javaengine.tests.wrapper

--- a/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/src/org/eclipse/gemoc/execution/sequential/javaengine/tests/wrapper/JavaEngineWrapper.xtend
+++ b/java_execution/java_engine/tests/org.eclipse.gemoc.execution.sequential.javaengine.tests/src/org/eclipse/gemoc/execution/sequential/javaengine/tests/wrapper/JavaEngineWrapper.xtend
@@ -26,7 +26,7 @@ class JavaEngineWrapper implements IEngineWrapper {
 	override prepare(ILanguageWrapper wrapper, IExecutableModel model, Set<String> addons, URI uri) {
 		engine = new PlainK3ExecutionEngine()
 		val IRunConfiguration runConf = new TestRunConfiguration(model, uri,wrapper,addons)
-		val IExecutionContext exeContext = new SequentialModelExecutionContext(runConf, ExecutionMode::Run);
+		val SequentialModelExecutionContext exeContext = new SequentialModelExecutionContext(runConf, ExecutionMode::Run);
 		exeContext.initializeResourceModel();
 		engine.initialize(exeContext)
 		engine.stopOnAddonError = true;


### PR DESCRIPTION
A while ago I had pushed a few classes I wrote to more easily run benchmarks of model executions in the studio. Afaik these classes are not used by any tests at the moment, despite the package name.

This PR simply updates the code of these classes to make them compile once more against the latest changes in the execution framework API. It should be harmless.

Signed-off-by: Erwan Bousse <erwan.bousse@ls2n.fr>