### PR TITLE
[tracing] Remove exceptions when no traced objects

### DIFF
--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceConstructor.java
@@ -286,12 +286,11 @@ public class GenericTraceConstructor implements ITraceConstructor {
 						for (EObject o : modelElements) {
 							addNewObjectToStateIfDynamic(o, state);
 							final TracedObject<?> tracedObj = exeToTraced.get(o);
-							if(tracedObj == null) {
-							Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
-									+ "Did you correctly declare it as Runtime Data ?", 
-									new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+							if(tracedObj != null) {
+								value.getReferenceValues().add(tracedObj);
+							} else {
+								value.getReferenceValues().add(o);
 							}
-							value.getReferenceValues().add(tracedObj);
 						}
 						firstValue = value;
 					} else {
@@ -303,12 +302,11 @@ public class GenericTraceConstructor implements ITraceConstructor {
 							addNewObjectToStateIfDynamic(o, state);
 							final SingleReferenceValue value = GenerictraceFactory.eINSTANCE.createSingleReferenceValue();
 							final TracedObject<?> tracedObj = exeToTraced.get(o);
-							if(tracedObj == null) {
-							Activator.error("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ");\n"
-									+ "Did you correctly declare it as Runtime Data ?", 
-									new Exception("Cannot find traced object for "+o+" (used by "+mutableProperty.getName()+" of "+object.eClass()+ ")"));
+							if(tracedObj != null) {
+								value.setReferenceValue(tracedObj);
+							} else {
+								value.setReferenceValue(o);
 							}
-							value.setReferenceValue(tracedObj);
 							firstValue = value;
 						}
 					}


### PR DESCRIPTION
Recently a change was made to throw exceptions when a reference stored in a trace cannot find a traced object as target. However, in such cases, the trace should actually simply store a reference to the original object of the executed model, and not to the traced object (eg. to point to a purely static "current state" in an FSM, while State is not a dynamic class at all and should not be).

This PR remove the exceptions and switches to the expected behavior.