### PR TITLE
Fix sirius wizard call and improve Sirius project creation for GEMOC

### DIFF
--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/.classpath
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -28,9 +28,10 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.xdsmlframework.ui.utils,
  org.eclipse.gemoc.commons.eclipse.ui,
  org.eclipse.swt,
- org.eclipse.ui.workbench
+ org.eclipse.ui.workbench,
+ org.eclipse.gemoc.dsl.model
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.sirius,
  org.eclipse.gemoc.xdsmlframework.extensions.sirius.command,
  org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards,

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -25,7 +25,10 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse.pde,
  org.eclipse.core.filesystem,
  org.eclipse.sirius.editor;bundle-version="2.0.7",
- org.eclipse.gemoc.xdsmlframework.ui.utils
+ org.eclipse.gemoc.xdsmlframework.ui.utils,
+ org.eclipse.gemoc.commons.eclipse.ui,
+ org.eclipse.swt,
+ org.eclipse.ui.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.sirius,

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.sirius.ext.base;bundle-version="2.0.7",
  org.eclipse.gemoc.commons.eclipse.pde,
  org.eclipse.core.filesystem,
- org.eclipse.sirius.editor;bundle-version="2.0.7"
+ org.eclipse.sirius.editor;bundle-version="2.0.7",
+ org.eclipse.gemoc.xdsmlframework.ui.utils
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.sirius,

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/plugin.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/plugin.xml
@@ -25,6 +25,18 @@
             Create a debug/animation representation for a GEMOC language. May create a new project, or modify or extend an existing Viewpoint Specification.
          </description>
       </wizard>
+      <wizard
+            category="org.eclipse.gemoc.xdsmlframework.category/org.eclipse.gemoc.xdsmlframework.fragment.category"
+            class="org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard"
+            hasPages="true"
+            icon="icons/IconeGemocLanguage-16.png"
+            id="org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard"
+            name="Sirius Viewpoint Specification Project 4 GEMOC language"
+            project="true">
+         <description>
+            Create a debug/animation representation for a GEMOC language. May create a new project, or modify or extend an existing Viewpoint Specification.
+         </description>
+      </wizard>
    </extension>
    <extension
          point="org.eclipse.ui.commands">

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
@@ -17,7 +17,6 @@ import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystemMana
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.ConsoleLogLevel;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.EclipseMessagingSystem;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 public class Activator extends AbstractUIPlugin {
@@ -54,7 +53,16 @@ public class Activator extends AbstractUIPlugin {
 		// eclipse logger
 		getDefault().getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, IStatus.ERROR, message, e));		
 	}
-
+	/**
+	 * This method logs an error message and an associated exception (as a trace)
+	 * @param message String
+	 */
+	public static void logWarnMessage(String message, Throwable e) {
+		if (message == null)
+			message= "";
+		// eclipse logger
+		getDefault().getLog().log(new Status(IStatus.WARNING, PLUGIN_ID, IStatus.ERROR, message, e));		
+	}
 	/*
 	 * (non-Javadoc)
 	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
@@ -10,19 +10,22 @@
  *******************************************************************************/
 package org.eclipse.gemoc.xdsmlframework.extensions.sirius;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystem;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystemManager;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.ConsoleLogLevel;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.ui.EclipseMessagingSystem;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
-public class Activator implements BundleActivator {
+public class Activator extends AbstractUIPlugin {
 
-	private static BundleContext context;
+	private static Activator plugin;
 
-	public static BundleContext getContext() {
-		return context;
+	public static Activator getDefault() {
+		return plugin;
 	}
 	
 	public static final String PLUGIN_ID = "org.eclipse.gemoc.xdsmlframework.extensions.sirius"; //$NON-NLS-1$
@@ -40,26 +43,34 @@ public class Activator implements BundleActivator {
 		}
 		return messagingSystem;
 	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext
-	 * )
+	
+	/**
+	 * This method logs an error message and an associated exception (as a trace)
+	 * @param message String
 	 */
-	public void start(BundleContext bundleContext) throws Exception {
-		Activator.context = bundleContext;
+	public static void logErrorMessage(String message, Throwable e) {
+		if (message == null)
+			message= "";
+		// eclipse logger
+		getDefault().getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, IStatus.ERROR, message, e));		
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
 	 */
-	public void stop(BundleContext bundleContext) throws Exception {
-		Activator.context = null;
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
 	}
 
 }

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
@@ -1,151 +1,73 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 Obeo.
+ * Copyright (c) 2017 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *    Obeo - initial API and implementation
- *    Gemoc - Copy the initial {@link ViewpointSpecificationProjectWizard} to set an initial project name    
+ *     Inria - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.StringTokenizer;
+import java.lang.reflect.InvocationTargetException;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.edit.ui.provider.ExtendedImageRegistry;
+import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.AbstractNewProjectWizardWithTemplates;
+import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.IProjectContentWizard;
+import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.ProjectTemplateApplicationOperation;
+import org.eclipse.gemoc.xdsmlframework.extensions.sirius.Activator;
+import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewGemocSiriusProjectMainWizardPage;
+import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewGemocSiriusProjectWizardFields;
+import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewODesignFileWizardPage;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.sirius.editor.editorPlugin.SiriusEditorPlugin;
 import org.eclipse.sirius.ui.tools.api.project.ViewpointSpecificationProject;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Combo;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
 
-public class NewGemocSiriusProjectWizard extends Wizard implements INewWizard {
+public class NewGemocSiriusProjectWizard extends AbstractNewProjectWizardWithTemplates implements INewWizard {
 
-	/**
-	 * Wizard id.
-	 */
-	public static final String ID = "org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard"; //$NON-NLS-1$
 
-	private IProject project;
-
-	/**
-	 * This is a new project wizard page.
-	 */
-	private WizardNewProjectCreationPage newProjectPage;
-
-	/**
-	 * This is the file creation page.
-	 */
-	private WizardNewODesignFilePage newOdesignPage;
-
+	
+	protected NewGemocSiriusProjectWizardFields 		context;	
+	
 	/**
 	 * Remember the workbench during initialization.
 	 */
 	private IWorkbench workbench;
-
-	private String initialProjectName;
-
+	
+	protected NewGemocSiriusProjectMainWizardPage 		projectPage;
+	//WizardPageCustomNewProjectK3Plugin 	projectPageCustom	 = new WizardPageCustomNewProjectK3Plugin(this.context);
+	
 	/**
-	 * Creates the project, all the directories and files and open the .odesign.
-	 * 
-	 * @return true if successful
+	 * This is the file creation page.
 	 */
-	@Override
-	public boolean performFinish() {
-		try {
-			// if user do not reach page 2, the VSM name is defined according to
-			// the project name
-			if (!newOdesignPage.isVsmNameChanged) {
-				newOdesignPage.modelName.setText(newOdesignPage
-						.extractModelName(newOdesignPage.firstPage
-								.getProjectName()));
-			}
-			ViewpointSpecificationProject
-					.createNewViewpointSpecificationProject(workbench,
-							newProjectPage.getProjectName(), newProjectPage
-									.getLocationPath(), newOdesignPage
-									.getModelName().getText(), newOdesignPage
-									.getInitialObjectName(), newOdesignPage
-									.getEncoding(), getContainer());
-			return true;
-		} catch (final CoreException e) {
-			final IStatus status = new Status(IStatus.ERROR,
-					SiriusEditorPlugin.PLUGIN_ID, IStatus.OK, e.getMessage(), e);
-			SiriusEditorPlugin.getPlugin().getLog().log(status);
-			return false;
-		}
-	}
+	private NewODesignFileWizardPage newOdesignPage;
 
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @see org.eclipse.ui.IWorkbenchWizard#init(org.eclipse.ui.IWorkbench,
-	 *      org.eclipse.jface.viewers.IStructuredSelection)
-	 */
-	public void init(final IWorkbench wkbch, final IStructuredSelection sel) {
-		this.workbench = wkbch;
-		setWindowTitle("New Viewpoint Specification Project");
-		setDefaultPageImageDescriptor(ExtendedImageRegistry.INSTANCE
-				.getImageDescriptor(SiriusEditorPlugin.INSTANCE
-						.getImage("full/wizban/banner_viewpoint_specification_project.gif")));
+	
+	public NewGemocSiriusProjectWizard() {
+		context = new NewGemocSiriusProjectWizardFields();
 	}
-
-	public IFile getModelFile() {
-		return ResourcesPlugin
-				.getWorkspace()
-				.getRoot()
-				.getFile(
-						project.getFullPath().append(
-								"description/"
-										+ newOdesignPage.getModelName()
-												.getText()));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @see org.eclipse.jface.wizard.Wizard#addPages()
-	 */
+	
 	@Override
 	public void addPages() {
-		newProjectPage = new NewGemocModelingProjectCreationWizardPage(
-				SiriusEditorPlugin.getPlugin().getString(
-						"_UI_ViewpointSpecificationProjectWizard_label")); //$NON-NLS-1$
-		newProjectPage.setInitialProjectName(getInitialProjectName()
-				+ ".design");
-		newProjectPage.setTitle(SiriusEditorPlugin.getPlugin().getString(
-				"_UI_ViewpointSpecificationProjectWizard_label")); //$NON-NLS-1$
-		newProjectPage.setDescription(SiriusEditorPlugin.getPlugin().getString(
-				"_UI_ViewpointSpecificationProjectWizard_description")); //$NON-NLS-1$        
-		project = ResourcesPlugin.getWorkspace().getRoot()
-				.getProject(newProjectPage.getProjectName());
-		addPage(newProjectPage);
-
-		newOdesignPage = new WizardNewODesignFilePage(
-				"ODesign Model", newProjectPage); //$NON-NLS-1$
+		projectPage			 = new NewGemocSiriusProjectMainWizardPage(this.context);
+		
+		addPage(projectPage);			
+		addPage(getTemplateListSelectionPage(context));
+		
+		newOdesignPage = new NewODesignFileWizardPage(
+				"ODesign Model", this.context); //$NON-NLS-1$
 		newOdesignPage.setTitle(SiriusEditorPlugin.getPlugin().getString(
 				"_UI_SiriusModelWizard_label")); //$NON-NLS-1$
 		newOdesignPage.setDescription(SiriusEditorPlugin.getPlugin().getString(
@@ -153,164 +75,97 @@ public class NewGemocSiriusProjectWizard extends Wizard implements INewWizard {
 		addPage(newOdesignPage);
 
 		super.addPages();
+		
 	}
-
-	/**
-	 * A page to configure the new model to create.
-	 * 
-	 * @author Obeo
-	 */
-	private static class WizardNewODesignFilePage extends WizardPage {
-		private static final String DOT = ".";
-
-		private List<String> encodings;
-
-		private Combo encodingField;
-
-		private ModifyListener validator = new ModifyListener() {
-			public void modifyText(final ModifyEvent e) {
-				setPageComplete(validatePage());
-				isVsmNameChanged = true;
-			}
-		};
-
-		private Text modelName;
-
-		// Check if VSM name has been modified
-		private Boolean isVsmNameChanged = false;
-
-		private WizardNewProjectCreationPage firstPage;
-
-		protected WizardNewODesignFilePage(final String pageName,
-				WizardNewProjectCreationPage firstPage) {
-			super(pageName);
-			this.firstPage = firstPage;
-		}
-
-		public Text getModelName() {
-			return modelName;
-		}
-
-		public String getEncoding() {
-			return encodingField.getText();
-		}
-
-		public String getInitialObjectName() {
-			return ViewpointSpecificationProject.INITIAL_OBJECT_NAME;
-		}
-
-		public void createControl(final Composite parent) {
-			final Composite composite = new Composite(parent, SWT.NONE);
-			final GridLayout layout = new GridLayout();
-			layout.numColumns = 2;
-			layout.verticalSpacing = 12;
-			composite.setLayout(layout);
-
-			GridData data = new GridData();
-			data.verticalAlignment = GridData.FILL;
-			data.grabExcessVerticalSpace = true;
-			data.horizontalAlignment = GridData.FILL;
-			composite.setLayoutData(data);
-
-			final Label modelNameLabel = new Label(composite, SWT.LEFT);
-			modelNameLabel.setText(SiriusEditorPlugin.getPlugin().getString(
-					"_UI_SiriusModelWizardName_label"));
-
-			data = new GridData();
-			data.horizontalAlignment = GridData.FILL;
-			modelNameLabel.setLayoutData(data);
-
-			modelName = new Text(composite, SWT.LEFT | SWT.BORDER);
-			modelName.setText(extractModelName(firstPage.getProjectName()));
-
-			data = new GridData();
-			data.horizontalAlignment = GridData.FILL;
-			data.grabExcessHorizontalSpace = true;
-			modelName.setLayoutData(data);
-			modelName.addModifyListener(validator);
-
-			final Label encodingLabel = new Label(composite, SWT.LEFT);
-			encodingLabel.setText(SiriusEditorPlugin.getPlugin().getString(
-					"_UI_XMLEncoding"));
-
-			data = new GridData();
-			data.horizontalAlignment = GridData.FILL;
-			encodingLabel.setLayoutData(data);
-
-			encodingField = new Combo(composite, SWT.BORDER);
-			data = new GridData();
-			data.horizontalAlignment = GridData.FILL;
-			data.grabExcessHorizontalSpace = true;
-			encodingField.setLayoutData(data);
-
-			for (final String string : getEncodings()) {
-				encodingField.add(string);
-			}
-
-			encodingField.select(0);
-			encodingField.addModifyListener(validator);
-
-			setPageComplete(validatePage());
-			setControl(composite);
-		}
-
-		protected boolean validatePage() {
-			return /* getInitialObjectName() != null && */getEncodings()
-					.contains(encodingField.getText())
-					&& getModelName()
-							.getText()
-							.endsWith(
-									DOT
-											+ ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION)
-					&& (getModelName().getText().length() > (ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION
-							.length() + 1));
-		}
-
-		private Collection<String> getEncodings() {
-			if (encodings == null) {
-				encodings = new ArrayList<String>();
-				final StringTokenizer stringTokenizer = new StringTokenizer(
-						SiriusEditorPlugin.getPlugin().getString(
-								"_UI_XMLEncodingChoices"));
-				while (stringTokenizer.hasMoreTokens()) {
-					encodings.add(stringTokenizer.nextToken());
+	
+	@Override
+	public void init(IWorkbench workbench, IStructuredSelection selection) {
+		this.workbench = workbench;
+		setWindowTitle("New Viewpoint Specification Project for GEMOC");
+		setDefaultPageImageDescriptor(ExtendedImageRegistry.INSTANCE
+				.getImageDescriptor(SiriusEditorPlugin.INSTANCE
+						.getImage("full/wizban/banner_viewpoint_specification_project.gif")));
+		
+	}
+	
+	@Override
+	public boolean performFinish() {	
+		try {
+			IWorkspace workspace = ResourcesPlugin.getWorkspace(); 
+			final IProjectDescription description = workspace.newProjectDescription(this.context.projectName);
+			if (!this.context.projectLocation.equals(workspace.getRoot().getLocation().toOSString()))
+				description.setLocation(new Path(this.context.projectLocation));
+			
+			final IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(this.context.projectName);
+			IWorkspaceRunnable operation = new IWorkspaceRunnable() {
+				public void run(IProgressMonitor monitor) throws CoreException {
+					
+					// if user do not reach page 2, the VSM name is defined according to
+					// the project name
+				/*	if (!newOdesignPage.isVsmNameChanged) {
+						newOdesignPage.modelName.setText(newOdesignPage
+								.extractModelName(newOdesignPage.firstPage
+										.getProjectName()));
+					}*/
+					Path projectLocationPath = new Path(context.projectLocation);
+					ViewpointSpecificationProject
+							.createNewViewpointSpecificationProject(workbench,
+									context.projectName, 
+									projectLocationPath, 
+									newOdesignPage.getModelName().getText(), 
+									newOdesignPage.getInitialObjectName(), 
+									newOdesignPage.getEncoding(), 
+									getContainer());
+					
+					// launch the template
+					
+					IProjectContentWizard contentWizard = templateSelectionPage.getSelectedWizard();
+					try {
+						getContainer().run(false, true, new ProjectTemplateApplicationOperation(context, project, contentWizard));
+					} catch (InvocationTargetException e) {
+						Activator.logErrorMessage(e.getMessage(), e);
+					} catch (InterruptedException e) {
+						Activator.logErrorMessage(e.getMessage(), e);
+					}
+					
+					//setClassPath(project, monitor);
+					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 				}
-			}
-			return encodings;
+			};
+			ResourcesPlugin.getWorkspace().run(operation, null);
+			
+		} catch (Exception exception) {
+			Activator.logErrorMessage(exception.getMessage(), exception);
+			return false;
 		}
-
-		public void setVisible(boolean visible) {
-			if (visible) {
-				if (!isVsmNameChanged) {
-					this.modelName.setText(extractModelName(firstPage
-							.getProjectName()));
-				}
-			}
-			super.setVisible(visible);
-		}
-
-		private String extractModelName(String projectName) {
-			String modelPrefixName = "";
-			if (projectName != null && projectName.contains(".")) {
-				String[] projectNames = projectName.split("[.]");
-				if ("design".equals(projectNames[projectNames.length - 1])) {
-					modelPrefixName = projectNames[projectNames.length - 2];
-				} else {
-					modelPrefixName = projectNames[projectNames.length - 1];
-				}
-			} else {
-				modelPrefixName = projectName;
-			}
-			return modelPrefixName + DOT
-					+ ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION;
-		}
+		return true;
+	}
+	
+	
+	@Override
+	public boolean isHelpAvailable() {
+		return true;
 	}
 
-	public void setInitialProjectName(String value) {
-		initialProjectName = value;
+	
+	public NewGemocSiriusProjectWizardFields getContext() {
+		return context;
+	}
+	
+
+
+	
+	
+	public NewGemocSiriusProjectMainWizardPage getPageProject() {
+		return this.projectPage;
 	}
 
-	public String getInitialProjectName() {
-		return initialProjectName;
+
+	@Override
+	public String getTargetPluginId() {		
+		return Activator.PLUGIN_ID;
 	}
+	
+	
+	
 }

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/NewGemocSiriusProjectWizard.java
@@ -10,8 +10,12 @@
  *******************************************************************************/
 package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.Optional;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -20,11 +24,21 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.edit.ui.provider.ExtendedImageRegistry;
+import org.eclipse.gemoc.commons.eclipse.core.resources.FileFinderVisitor;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.AbstractNewProjectWizardWithTemplates;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.IProjectContentWizard;
 import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.ProjectTemplateApplicationOperation;
+import org.eclipse.gemoc.dsl.Dsl;
+import org.eclipse.gemoc.dsl.DslFactory;
+import org.eclipse.gemoc.dsl.DslPackage;
+import org.eclipse.gemoc.dsl.Entry;
 import org.eclipse.gemoc.xdsmlframework.extensions.sirius.Activator;
 import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewGemocSiriusProjectMainWizardPage;
 import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages.NewGemocSiriusProjectWizardFields;
@@ -117,8 +131,7 @@ public class NewGemocSiriusProjectWizard extends AbstractNewProjectWizardWithTem
 									newOdesignPage.getEncoding(), 
 									getContainer());
 					
-					// launch the template
-					
+					// launch the template is selected
 					IProjectContentWizard contentWizard = templateSelectionPage.getSelectedWizard();
 					try {
 						getContainer().run(false, true, new ProjectTemplateApplicationOperation(context, project, contentWizard));
@@ -128,7 +141,11 @@ public class NewGemocSiriusProjectWizard extends AbstractNewProjectWizardWithTem
 						Activator.logErrorMessage(e.getMessage(), e);
 					}
 					
-					//setClassPath(project, monitor);
+					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+					
+					waitForAutoBuild();
+					updateDsl(project);
+					
 					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 				}
 			};
@@ -141,7 +158,61 @@ public class NewGemocSiriusProjectWizard extends AbstractNewProjectWizardWithTem
 		return true;
 	}
 	
+	/**
+	 * update the dsl file with the indication of the sirius project 
+	 * @param siriusProject
+	 */
+	protected void updateDsl(IProject siriusProject){
+		
+		FileFinderVisitor odesignProjectVisitor = new FileFinderVisitor("odesign");
+		try {
+			siriusProject.accept(odesignProjectVisitor);
+			IFile odesignIFile = odesignProjectVisitor.getFile();
+			if (odesignIFile != null) {
+				// the dsl file that will be updated
+				Resource res = (new ResourceSetImpl()).getResource(URI.createURI(context.dslFilePath), true);
+				Dsl dsl = (Dsl) res.getContents().get(0);
+				
+				Optional<Entry> sirius = dsl.getEntries()
+					.stream()
+					.filter(entry -> entry.getKey().equals("sirius"))
+					.findFirst();
+				if(sirius.isPresent()) {
+					sirius.get().setValue(odesignIFile.getFullPath().toOSString());
+				}
+				else {
+					Entry siriusEntry = ((DslFactory)DslPackage.eINSTANCE.getEFactoryInstance()).createEntry();
+					siriusEntry.setKey("sirius");
+					siriusEntry.setValue(odesignIFile.getFullPath().toOSString());
+					dsl.getEntries().add(siriusEntry);
+				}
+				try {
+					res.save(Collections.emptyMap());
+				} catch (IOException e) {
+					Activator.logErrorMessage(e.getMessage(), e);
+				}
+			}
+		} catch (CoreException e) {
+			Activator.logErrorMessage(e.getMessage(), e);
+		}
+	}
 	
+	/**
+	 * wait that eclipse worskace has finish all its background builds
+	 */
+	protected void waitForAutoBuild() {
+		boolean wasInterrupted = false;
+		do {
+			try {
+				Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD,	null);
+				wasInterrupted = false;
+			} catch (OperationCanceledException e) {
+				Activator.logWarnMessage(e.getMessage(), e);
+			} catch (InterruptedException e) {
+				wasInterrupted = true;
+			}
+		} while (wasInterrupted);
+	}
 	@Override
 	public boolean isHelpAvailable() {
 		return true;

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
@@ -1,0 +1,362 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.gemoc.commons.eclipse.core.resources.IFileUtils;
+import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ErrorMessage;
+import org.eclipse.gemoc.commons.eclipse.ui.dialogs.SelectAnyIFileDialog;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.sirius.editor.editorPlugin.SiriusEditorPlugin;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+
+
+public class NewGemocSiriusProjectMainWizardPage extends WizardPage {
+
+	protected NewGemocSiriusProjectWizardFields		context;
+	
+	protected static final List<String> FILE_EXTENSIONS = Arrays.asList(new String [] { "ecore" });
+	protected ErrorMessage[] errorMessage;
+	protected boolean 	enableNext = true;
+	
+	protected Composite 	container;
+	protected Label 		lblProjectName;
+//	protected Label 		lblTemplateEcore;
+	protected Text 			txtProjectName;
+	protected Text 			txtProjectLocation;
+//	protected Text 			txtPathEcore;
+	protected Button		btnBrowseLocation;
+//	protected Button 		btnBrowseEcore;
+	//protected Button 		btnCreateEmfProject;
+	protected Button 		btnCheckLocation;
+//	protected Button 		btnCheckEcore;
+//	protected Button 		btnCheckSLE;
+	
+	protected Text			txtBaseGemocProject;
+	protected Button 		btnBrowseGemocProject;
+	protected Text			txtDSLFile;
+	protected Button 		btnBrowseDSLFile;
+	protected Button 		btnCheckUpdateGemocProject;
+	
+	protected Group 		grpGeneral;
+	protected Group 		grpBaseGemocProject;
+//protected Group 		grpSLEOptions;
+	protected Group 		grpTemplateOptions;
+
+	public NewGemocSiriusProjectMainWizardPage(NewGemocSiriusProjectWizardFields context){
+		super("wizardPage");
+		this.context = context;
+		setTitle(SiriusEditorPlugin.getPlugin().getString(
+				"_UI_ViewpointSpecificationProjectWizard_label")+" for GEMOC");
+		setDescription("This wizard creates a new Sirius specification project for GEMOC");
+		this.errorMessage =  new ErrorMessage[4];
+		this.errorMessage[0] = new ErrorMessage("A project with this name already exists.", false);
+		this.errorMessage[1] = new ErrorMessage("Please select an ecore file.", false);
+		this.errorMessage[2] = new ErrorMessage("dsl file doesn't exist", false);
+		this.errorMessage[3] = new ErrorMessage("base dsl file not set", false);
+	}
+	
+	/**
+	 * Constructor for KermetaNewWizardDashboard.
+	 * @param pageName
+	 */
+	public NewGemocSiriusProjectMainWizardPage(ISelection selection) {
+		super("wizardPage");
+		setTitle(SiriusEditorPlugin.getPlugin().getString(
+				"_UI_ViewpointSpecificationProjectWizard_label")+" for GEMOC");
+		setDescription("This wizard creates a new Sirius specification project for GEMOC");
+		setPageComplete(true);
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		container = new Composite(parent, SWT.NULL);
+		container.setLayout(new GridLayout(1, false));
+		
+		
+		//-----------------------------------------------
+		grpGeneral = new Group(container, SWT.NONE);
+		grpGeneral.setText("General");
+		grpGeneral.setLayout(new GridLayout(4, false));
+
+		lblProjectName = new Label(grpGeneral, SWT.NONE);
+		lblProjectName.setText("project name ");
+		new Label(grpGeneral, SWT.NONE);
+		new Label(grpGeneral, SWT.NONE);
+		new Label(grpGeneral, SWT.NONE);
+		
+		txtProjectName = new Text(grpGeneral, SWT.BORDER);
+		txtProjectName.setText(this.context.projectName);
+		GridData projectNameGrid = new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1);
+		projectNameGrid.widthHint = 500;
+		txtProjectName.setLayoutData(projectNameGrid);
+		new Label(grpGeneral, SWT.NONE);
+				
+		txtProjectName.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent arg0) {
+				validatePage();
+				updateNameProject(txtProjectName.getText());
+			}
+		});
+		
+		btnCheckLocation = new Button(grpGeneral, SWT.CHECK);
+		btnCheckLocation.setText("use default location");
+		btnCheckLocation.setSelection(true);
+		new Label(grpGeneral, SWT.NONE);
+		new Label(grpGeneral, SWT.NONE);
+		new Label(grpGeneral, SWT.NONE);
+		
+		btnCheckLocation.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (btnCheckLocation.getSelection()) {
+					txtProjectLocation.setEnabled(false);
+					btnBrowseLocation.setEnabled(false);
+				}
+				else {
+					txtProjectLocation.setEnabled(true);
+					btnBrowseLocation.setEnabled(true);
+				} 
+			}
+		});
+		txtProjectLocation = new Text(grpGeneral, SWT.BORDER);
+		txtProjectLocation.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+		txtProjectLocation.setText(this.context.projectLocation);
+		
+		btnBrowseLocation = new Button(grpGeneral, SWT.NONE);
+		btnBrowseLocation.setText("Browse...");
+		
+		btnBrowseLocation.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				txtProjectLocation.setText(locationDialog());
+			}
+		});
+		
+		//-----------------------------------------------
+
+		grpBaseGemocProject = new Group(container, SWT.NONE);
+		grpBaseGemocProject.setText("Base XDSML");
+		//grpBaseGemocProject.setLayout(new FillLayout(SWT.HORIZONTAL));
+		grpBaseGemocProject.setLayout(new GridLayout());
+		grpBaseGemocProject.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		//createGemocProjectNameComposite(grpBaseGemocProject);
+		createDslFileComposite(grpBaseGemocProject);
+		
+		//-----------------------------------------------
+		
+		//initialization of enabled state of controls
+		txtProjectLocation.setEnabled(false);
+		btnBrowseLocation.setEnabled(false);
+		
+		validatePage();
+		
+		// Required to avoid an error in the system
+		setControl(container);
+		setPageComplete(true);
+	}
+	
+	private Text createDslFileComposite(final Composite composite) {
+		GridLayout layout;
+		final Composite dslFileComposite = new Composite(composite,
+				SWT.NONE);
+		dslFileComposite.setLayoutData(new GridData(
+				GridData.FILL_HORIZONTAL));
+		layout = new GridLayout();
+		layout.numColumns = 3;
+		dslFileComposite.setLayout(layout);
+		Label label = new Label(dslFileComposite, SWT.None);
+		label.setText("DSL file path:");
+		txtDSLFile = new Text(dslFileComposite, SWT.SINGLE);
+		txtDSLFile.setText(this.context.dslFilePath);
+		txtDSLFile.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		txtDSLFile.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent e) {
+				validatePage();
+				updateDslFilePath(txtDSLFile.getText());
+				try {
+					IFile dslFile = IFileUtils.getIFileFromWorkspaceOrFileSystem(txtDSLFile.getText());
+					if(dslFile.exists()) {
+						updateBaseGemocProject(dslFile.getProject().getName());
+					}
+				} catch (CoreException e1) {}
+			}
+		});
+		btnBrowseDSLFile = new Button(dslFileComposite, SWT.NONE);
+		btnBrowseDSLFile.setText("Browse...");
+		
+		btnBrowseDSLFile.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				SelectAnyIFileDialog dsldialog = new SelectAnyIFileDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell());
+				dsldialog.setPattern("*.dsl");
+				dsldialog.setTitle("Select base DSL file");
+				if (dsldialog.open() == Dialog.OK) {
+					Object[] selections = dsldialog.getResult();
+					if(selections != null 
+						&& selections.length != 0
+						&& selections[0] instanceof IFile 
+					){
+						IFile dslFile = (IFile) selections[0];
+						txtDSLFile.setText(dslFile.getFullPath().toString());
+						//validatePage();
+					}
+				}
+			}
+		});
+
+
+		return txtDSLFile;
+	}
+
+	protected String locationDialog () {
+		DirectoryDialog dirDialog = new DirectoryDialog(new Shell());
+	    dirDialog.setText("Select location directory");
+	    this.context.projectLocation = dirDialog.open();
+	    return this.context.projectLocation;
+	}
+
+	
+	protected void activErrorMessage (int index, boolean bActiv) {
+		this.errorMessage[index].setActive(bActiv);
+		setMessageError();
+	}
+	
+	protected boolean existNameProject () {
+		boolean bFinder = false;
+		int i = 0;
+		while (bFinder == false && i < ResourcesPlugin.getWorkspace().getRoot().getProjects().length) {
+  		  if (ResourcesPlugin.getWorkspace().getRoot().getProjects()[i].getName().contentEquals(txtProjectName.getText())) {
+  			  bFinder = true;
+  		  }
+  		  i++;
+		}
+		return bFinder;
+	}
+	
+	private boolean isSet(Text text) {
+		return text != null && !"".equals(text.getText());
+	}
+	
+	
+	protected boolean validatePage() {
+		boolean validPage = true;
+		/*if (validProjectName && resourceExistsInWorkspace()) {
+			validProjectName = false;
+		}
+		// check for collision with existing folder of different case on disk
+		if (validProjectName && !StringUtil.isEmpty(getProjectName())) {
+			if (resourceExistsOnDisk()) {
+				validProjectName = false;
+			}
+		}*/
+		if (existNameProject()) {
+			activErrorMessage (0, true);
+			validPage = false;
+		}
+		else {
+			  activErrorMessage(0 , false);			
+		}
+		if(isSet(txtDSLFile)) {
+			activErrorMessage (3, false);
+		} else {
+			activErrorMessage (3, true);
+			validPage = false;
+		}
+		if(isSet(txtDSLFile) ) {
+			IFile dslFile;
+			try {
+				dslFile = IFileUtils.getIFileFromWorkspaceOrFileSystem(txtDSLFile.getText());
+				if(dslFile.exists()) {
+					activErrorMessage (2, false);
+				} else {
+					activErrorMessage (2, true);
+					validPage = false;
+				}
+			} catch (CoreException | IllegalArgumentException e) {
+				activErrorMessage (2, true);
+				validPage = false;
+			}
+		}
+		if(validPage ) {
+			setPageComplete(true);
+		} else {
+			setPageComplete(false);
+		}
+		return validPage;
+	}
+	
+	protected void setMessageError () {
+		StringBuffer result = new StringBuffer();
+		for (int i = 0; i < this.errorMessage.length; i++) {
+			if (this.errorMessage[i].isActive()) {
+				result.append(this.errorMessage[i].getMessageError() + "\n");
+			}
+		}
+		if (result.length() > 0) {
+			setErrorMessage(result.toString());
+		}
+		else {
+			setErrorMessage(null);
+		}
+	}
+	
+
+	protected void updateUpdateDSLFile (boolean bState) {
+		this.context.updateGemocDSLFile = bState;
+		btnCheckUpdateGemocProject.setSelection(bState);
+	}
+	
+	protected void updateNameProject (String nameProject) {
+		this.context.projectName = nameProject;
+	}
+	protected void updateBaseGemocProject(String text) {
+		this.context.baseGemocProject = text;
+	}
+	protected void updateDslFilePath(String text) {
+		this.context.dslFilePath = text;
+	}
+	
+	@Override
+	public boolean canFlipToNextPage () {
+		return enableNext;
+	}
+	
+
+	public void setProjectName(String nameProject) {
+		this.txtProjectName.setText(nameProject);
+		this.context.projectName = nameProject;
+	}
+	
+}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
@@ -65,7 +65,6 @@ public class NewGemocSiriusProjectMainWizardPage extends WizardPage {
 	protected Button 		btnBrowseGemocProject;
 	protected Text			txtDSLFile;
 	protected Button 		btnBrowseDSLFile;
-	protected Button 		btnCheckUpdateGemocProject;
 	
 	protected Group 		grpGeneral;
 	protected Group 		grpBaseGemocProject;
@@ -330,12 +329,6 @@ public class NewGemocSiriusProjectMainWizardPage extends WizardPage {
 		else {
 			setErrorMessage(null);
 		}
-	}
-	
-
-	protected void updateUpdateDSLFile (boolean bState) {
-		this.context.updateGemocDSLFile = bState;
-		btnCheckUpdateGemocProject.setSelection(bState);
 	}
 	
 	protected void updateNameProject (String nameProject) {

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectMainWizardPage.java
@@ -151,6 +151,13 @@ public class NewGemocSiriusProjectMainWizardPage extends WizardPage {
 		txtProjectLocation = new Text(grpGeneral, SWT.BORDER);
 		txtProjectLocation.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		txtProjectLocation.setText(this.context.projectLocation);
+		txtProjectLocation.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent arg0) {
+				validatePage();
+				updateProjectLocation(txtProjectLocation.getText());
+			}
+		});
 		
 		btnBrowseLocation = new Button(grpGeneral, SWT.NONE);
 		btnBrowseLocation.setText("Browse...");
@@ -333,6 +340,13 @@ public class NewGemocSiriusProjectMainWizardPage extends WizardPage {
 	
 	protected void updateNameProject (String nameProject) {
 		this.context.projectName = nameProject;
+		if(btnCheckLocation.getSelection()) {
+			// if use default location then also update the location field accordingly
+			txtProjectLocation.setText(ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString()+"/"+nameProject);
+		}
+	}
+	protected void updateProjectLocation (String projectLocation) {
+		this.context.projectLocation = projectLocation;
 	}
 	protected void updateBaseGemocProject(String text) {
 		this.context.baseGemocProject = text;

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectWizardFields.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectWizardFields.java
@@ -26,9 +26,9 @@ public class NewGemocSiriusProjectWizardFields extends BaseProjectWizardFields {
 	
 	public NewGemocSiriusProjectWizardFields () {
 		super();
-		this.projectLocation 		= ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString();
 		this.projectName 			= "org.company.language.design";
-
+		this.projectLocation 		= ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString()+"/"+this.projectName;
+		
 		this.baseGemocProject		= "org.company.language";
 		this.updateGemocDSLFile		= true;
 		this.dslFilePath			= "";

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectWizardFields.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewGemocSiriusProjectWizardFields.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.ui.BaseProjectWizardFields;
+
+public class NewGemocSiriusProjectWizardFields extends BaseProjectWizardFields {
+	
+	// main fields (Ie. that are present in the main wizard page)
+
+	public String 			baseGemocProject;
+	public boolean			updateGemocDSLFile = true;
+	public String 			dslFilePath;
+	
+
+	
+	
+	public NewGemocSiriusProjectWizardFields () {
+		super();
+		this.projectLocation 		= ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString();
+		this.projectName 			= "org.company.language.design";
+
+		this.baseGemocProject		= "org.company.language";
+		this.updateGemocDSLFile		= true;
+		this.dslFilePath			= "";
+	}
+}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewODesignFileWizardPage.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/NewODesignFileWizardPage.java
@@ -1,0 +1,164 @@
+package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.sirius.editor.editorPlugin.SiriusEditorPlugin;
+import org.eclipse.sirius.ui.tools.api.project.ViewpointSpecificationProject;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+
+public class NewODesignFileWizardPage extends WizardPage {
+	private static final String DOT = ".";
+
+	private List<String> encodings;
+
+	private Combo encodingField;
+
+	private ModifyListener validator = new ModifyListener() {
+		public void modifyText(final ModifyEvent e) {
+			setPageComplete(validatePage());
+			isVsmNameChanged = true;
+		}
+	};
+
+	private Text modelName;
+
+	// Check if VSM name has been modified
+	private Boolean isVsmNameChanged = false;
+
+	private NewGemocSiriusProjectWizardFields context;
+
+	public NewODesignFileWizardPage(final String pageName,
+			NewGemocSiriusProjectWizardFields context) {
+		super(pageName);
+		this.context = context;
+	}
+
+	public Text getModelName() {
+		return modelName;
+	}
+
+	public String getEncoding() {
+		return encodingField.getText();
+	}
+
+	public String getInitialObjectName() {
+		return ViewpointSpecificationProject.INITIAL_OBJECT_NAME;
+	}
+
+	public void createControl(final Composite parent) {
+		final Composite composite = new Composite(parent, SWT.NONE);
+		final GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		layout.verticalSpacing = 12;
+		composite.setLayout(layout);
+
+		GridData data = new GridData();
+		data.verticalAlignment = GridData.FILL;
+		data.grabExcessVerticalSpace = true;
+		data.horizontalAlignment = GridData.FILL;
+		composite.setLayoutData(data);
+
+		final Label modelNameLabel = new Label(composite, SWT.LEFT);
+		modelNameLabel.setText(SiriusEditorPlugin.getPlugin().getString(
+				"_UI_SiriusModelWizardName_label"));
+
+		data = new GridData();
+		data.horizontalAlignment = GridData.FILL;
+		modelNameLabel.setLayoutData(data);
+
+		modelName = new Text(composite, SWT.LEFT | SWT.BORDER);
+		modelName.setText(extractModelName(context.projectName));
+
+		data = new GridData();
+		data.horizontalAlignment = GridData.FILL;
+		data.grabExcessHorizontalSpace = true;
+		modelName.setLayoutData(data);
+		modelName.addModifyListener(validator);
+
+		final Label encodingLabel = new Label(composite, SWT.LEFT);
+		encodingLabel.setText(SiriusEditorPlugin.getPlugin().getString(
+				"_UI_XMLEncoding"));
+
+		data = new GridData();
+		data.horizontalAlignment = GridData.FILL;
+		encodingLabel.setLayoutData(data);
+
+		encodingField = new Combo(composite, SWT.BORDER);
+		data = new GridData();
+		data.horizontalAlignment = GridData.FILL;
+		data.grabExcessHorizontalSpace = true;
+		encodingField.setLayoutData(data);
+
+		for (final String string : getEncodings()) {
+			encodingField.add(string);
+		}
+
+		encodingField.select(0);
+		encodingField.addModifyListener(validator);
+
+		setPageComplete(validatePage());
+		setControl(composite);
+	}
+
+	protected boolean validatePage() {
+		return /* getInitialObjectName() != null && */getEncodings()
+				.contains(encodingField.getText())
+				&& getModelName()
+						.getText()
+						.endsWith(
+								DOT
+										+ ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION)
+				&& (getModelName().getText().length() > (ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION
+						.length() + 1));
+	}
+
+	private Collection<String> getEncodings() {
+		if (encodings == null) {
+			encodings = new ArrayList<String>();
+			final StringTokenizer stringTokenizer = new StringTokenizer(
+					SiriusEditorPlugin.getPlugin().getString(
+							"_UI_XMLEncodingChoices"));
+			while (stringTokenizer.hasMoreTokens()) {
+				encodings.add(stringTokenizer.nextToken());
+			}
+		}
+		return encodings;
+	}
+
+	public void setVisible(boolean visible) {
+		if (visible) {
+			if (!isVsmNameChanged) {
+				this.modelName.setText(extractModelName(context.projectName));
+			}
+		}
+		super.setVisible(visible);
+	}
+
+	private String extractModelName(String projectName) {
+		String modelPrefixName = "";
+		if (projectName != null && projectName.contains(".")) {
+			String[] projectNames = projectName.split("[.]");
+			if ("design".equals(projectNames[projectNames.length - 1])) {
+				modelPrefixName = projectNames[projectNames.length - 2];
+			} else {
+				modelPrefixName = projectNames[projectNames.length - 1];
+			}
+		} else {
+			modelPrefixName = projectName;
+		}
+		return modelPrefixName + DOT
+				+ ViewpointSpecificationProject.VIEWPOINT_MODEL_EXTENSION;
+	}
+}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/commands/AbstractGemocLanguageProjectHandler.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/commands/AbstractGemocLanguageProjectHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.gemoc.commons.eclipse.core.resources.FileFinderVisitor;
 import org.eclipse.gemoc.dsl.Dsl;
+import org.eclipse.gemoc.xdsmlframework.ide.ui.Activator;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -116,7 +117,7 @@ public abstract class AbstractGemocLanguageProjectHandler extends AbstractHandle
 				}
 			}
 		} catch (CoreException e) {
-			e.printStackTrace();
+			Activator.error(e.getMessage(), e);
 		}
 		return null;
 	}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateAnimatorProjectWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateAnimatorProjectWizardContextAction.java
@@ -77,9 +77,10 @@ public class CreateAnimatorProjectWizardContextAction {
 	}
 
 	protected void createNewODProject() {
+		final String wizardId = org.eclipse.gemoc.xdsmlframework.extensions.sirius.Activator.PLUGIN_ID
+				+ ".wizards.NewGemocDebugRepresentationWizard";
 		final IWizardDescriptor descriptor = WizardFinder
-				.findNewWizardDescriptor(org.eclipse.gemoc.xdsmlframework.extensions.sirius.Activator.PLUGIN_ID
-						+ ".wizards.NewGemocDebugRepresentationWizard");
+				.findNewWizardDescriptor(wizardId);
 		// Then if we have a wizard, open it.
 		if (descriptor != null) {
 			NewProjectWorkspaceListener workspaceListener = new NewProjectWorkspaceListener();
@@ -127,7 +128,7 @@ public class CreateAnimatorProjectWizardContextAction {
 			}
 		} else {
 			Activator
-					.error("wizard with id=org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocDebugRepresentationWizard not found",
+					.error("wizard with id="+wizardId+" not found",
 							null);
 		}
 	}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateDomainModelWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateDomainModelWizardContextAction.java
@@ -81,9 +81,9 @@ public class CreateDomainModelWizardContextAction {
 
 		// "org.eclipse.emf.importer.ui.EMFProjectWizard" = create EMFProject
 		// from existing Ecore file
-
+		final String wizardId = "org.eclipse.ecoretools.emf.design.wizardID";
 		IWizardDescriptor descriptor = WizardFinder
-				.findNewWizardDescriptor("org.eclipse.ecoretools.emf.design.wizardID");
+				.findNewWizardDescriptor(wizardId);
 
 		// Then if we have a wizard, open it.
 		if (descriptor != null) {
@@ -128,7 +128,12 @@ public class CreateDomainModelWizardContextAction {
 				ResourcesPlugin.getWorkspace().removeResourceChangeListener(
 						workspaceListener);
 			}
+		} else {
+			Activator
+			.error("wizard with id="+wizardId+" not found",
+					null);
 		}
+		
 	}
 
 	protected void selectExistingEMFProject() {

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateDomainModelWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateDomainModelWizardContextAction.java
@@ -24,6 +24,7 @@ import org.eclipse.gemoc.commons.eclipse.core.resources.FileFinderVisitor;
 import org.eclipse.gemoc.commons.eclipse.core.resources.NewProjectWorkspaceListener;
 import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.xdsmlframework.ide.ui.Activator;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectEMFIProjectDialog;
 
 import org.eclipse.gemoc.commons.eclipse.pde.manifest.ManifestChanger;
@@ -96,7 +97,7 @@ public class CreateDomainModelWizardContextAction {
 				wizard = descriptor.createWizard();
 				// this wizard need some dedicated initialization
 				((EcoreModelerWizard) wizard)
-						.setInitialProjectName(MelangeXDSMLProjectHelper
+						.setInitialProjectName(XDSMLProjectHelper
 								.baseProjectName(gemocLanguageIProject)
 								+ ".model");
 				((EcoreModelerWizard) wizard).init(PlatformUI.getWorkbench(),

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
@@ -30,6 +30,7 @@ import org.eclipse.gemoc.commons.eclipse.core.resources.NewProjectWorkspaceListe
 import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard;
 import org.eclipse.gemoc.xdsmlframework.ide.ui.Activator;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 
 //import org.eclipse.emf.ecoretools.design.wizard.EcoreModelerWizard;
 
@@ -219,7 +220,7 @@ public class CreateEditorProjectWizardContextAction {
 			try {
 				IWorkbenchWizard wizard;
 				wizard = descriptor.createWizard();
-				 ((NewGemocSiriusProjectWizard)wizard).setInitialProjectName(MelangeXDSMLProjectHelper
+				 ((NewGemocSiriusProjectWizard)wizard).setInitialProjectName(XDSMLProjectHelper
 						                                                .baseProjectName(gemocLanguageIProject));
 
 				IWorkbench workbench = PlatformUI.getWorkbench();

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
@@ -220,8 +220,23 @@ public class CreateEditorProjectWizardContextAction {
 			try {
 				IWorkbenchWizard wizard;
 				wizard = descriptor.createWizard();
-				 ((NewGemocSiriusProjectWizard)wizard).setInitialProjectName(XDSMLProjectHelper
-						                                                .baseProjectName(gemocLanguageIProject));
+				NewGemocSiriusProjectWizard gsWizard = ((NewGemocSiriusProjectWizard)wizard);
+				gsWizard.getContext().projectName= (XDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".design");
+				
+				FileFinderVisitor dslProjectVisitor = new FileFinderVisitor("dsl");
+				try {
+					gemocLanguageIProject.accept(dslProjectVisitor);
+					for (IFile projectDslIFile : dslProjectVisitor.getFiles()) {
+						// consider first dsl file in the project
+						if (!(projectDslIFile.getFullPath().toString().contains("/bin/")
+								| projectDslIFile.getFullPath().toString().contains("/target/"))) {
+							gsWizard.getContext().dslFilePath = projectDslIFile.getFullPath().toString();
+							break;
+						}
+					}
+				} catch (CoreException e) {
+					Activator.error(e.getMessage(), e);
+				}
 
 				IWorkbench workbench = PlatformUI.getWorkbench();
 				wizard.init(workbench, null);

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
@@ -222,6 +222,7 @@ public class CreateEditorProjectWizardContextAction {
 				wizard = descriptor.createWizard();
 				NewGemocSiriusProjectWizard gsWizard = ((NewGemocSiriusProjectWizard)wizard);
 				gsWizard.getContext().projectName= (XDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".design");
+				gsWizard.getContext().projectLocation = ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString()+"/"+gsWizard.getContext().projectName;
 				
 				FileFinderVisitor dslProjectVisitor = new FileFinderVisitor("dsl");
 				try {

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/xdsml/wizards/CreateEditorProjectWizardContextAction.java
@@ -143,9 +143,9 @@ public class CreateEditorProjectWizardContextAction {
 		// wizard id =
 		// org.eclipse.xtext.xtext.ui.wizard.ecore2xtext.NewXtextProjectFromEcoreWizard
 		// launch the appropriate wizard
-
+		final String wizardId = "org.eclipse.xtext.xtext.ui.wizard.ecore2xtext.NewXtextProjectFromEcoreWizard";
 		IWizardDescriptor descriptor = WizardFinder
-				.findNewWizardDescriptor("org.eclipse.xtext.xtext.ui.wizard.ecore2xtext.NewXtextProjectFromEcoreWizard");
+				.findNewWizardDescriptor(wizardId);
 		// Then if we have a wizard, open it.
 		if (descriptor != null) {
 			// add a listener to capture the creation of the resulting project
@@ -202,14 +202,15 @@ public class CreateEditorProjectWizardContextAction {
 			}
 		} else {
 			Activator
-					.error("wizard with id=org.eclipse.xtext.xtext.ui.wizard.ecore2xtext.NewXtextProjectFromEcoreWizard not found",
+					.error("wizard with id="+wizardId+" not found",
 							null);
 		}
 	}
 
 	protected void createNewODProject() {
+		final String wizardId = "org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard";
 		final IWizardDescriptor descriptor = WizardFinder
-				.findNewWizardDescriptor("org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.NewGemocSiriusProjectWizard");
+				.findNewWizardDescriptor(wizardId);
 		// Then if we have a wizard, open it.
 		if (descriptor != null) {
 			NewProjectWorkspaceListener workspaceListener = new NewProjectWorkspaceListener();
@@ -251,7 +252,7 @@ public class CreateEditorProjectWizardContextAction {
 			}
 		} else {
 			Activator
-					.error("wizard with id=org.eclipse.sirius.ui.specificationproject.wizard not found",
+					.error("wizard with id="+wizardId+" not found",
 							null);
 		}
 	}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/src/org/eclipse/gemoc/xdsmlframework/ui/utils/XDSMLProjectHelper.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ui.utils/src/org/eclipse/gemoc/xdsmlframework/ui/utils/XDSMLProjectHelper.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
-package org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards;
+package org.eclipse.gemoc.xdsmlframework.ui.utils;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -21,20 +21,27 @@ import fr.inria.diverse.melange.metamodel.melange.Import;
 import fr.inria.diverse.melange.metamodel.melange.Language;
 import fr.inria.diverse.melange.metamodel.melange.Operator;
 
-public class MelangeXDSMLProjectHelper {
+public class XDSMLProjectHelper {
 
 	/**
-	 * Computer the base name for a project base on xdsml project
-	 * ie. if it ends with .xdsml this suffix is removed
+	 * Computes the base name from an xdsml/dsml project
+	 * ie. if it ends with .xdsml or .dsml this suffix is removed
 	 * @param xdsmlProject
 	 * @return
 	 */
 	public static String baseProjectName(IProject xdsmlProject){
-		int index = xdsmlProject.getName().indexOf(".xdsml");
+		return baseProjectName(xdsmlProject.getName());
+	}
+	public static String baseProjectName(String xdsmlProjectName){
+		int index = xdsmlProjectName.indexOf(".xdsml");
 		if(index != -1){
-			return xdsmlProject.getName().substring(0, index);		
+			return xdsmlProjectName.substring(0, index);		
 		}
-		return xdsmlProject.getName();
+		index = xdsmlProjectName.indexOf(".dsml");
+		if(index != -1){
+			return xdsmlProjectName.substring(0, index);		
+		}
+		return xdsmlProjectName;
 	}
 	
 	public static String getFirstEcorePath(Language language){

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateSiriusEditorProjectHandler.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateSiriusEditorProjectHandler.java
@@ -10,26 +10,10 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.commands;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Optional;
-
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.gemoc.dsl.Dsl;
-import org.eclipse.gemoc.dsl.DslFactory;
-import org.eclipse.gemoc.dsl.DslPackage;
-import org.eclipse.gemoc.dsl.Entry;
-import org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.Activator;
 import org.eclipse.gemoc.xdsmlframework.ide.ui.commands.AbstractDslSelectHandler;
 import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.CreateEditorProjectWizardContextAction;
 import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.CreateEditorProjectWizardContextAction.CreateEditorProjectAction;
@@ -45,56 +29,13 @@ public class CreateSiriusEditorProjectHandler extends AbstractDslSelectHandler i
 		action.actionToExecute = CreateEditorProjectAction.CREATE_NEW_SIRIUS_PROJECT;
 		action.execute();
 		
-		if(action.getSiriusPath() != null){
-			waitForAutoBuild();
-			updateDsl(event,updatedGemocLanguageProject,language,action.getSiriusPath());
-		}
 		
 		return null;
 	}
 
 	@Override
 	public String getSelectionMessage() {
-		return "Select Melange language that will be used to initialize the new Sirius project";
+		return "Select language (*.dsl file) that will be used to initialize the new Sirius project";
 	}
 
-	protected void updateDsl(ExecutionEvent event, IProject project, String language, String siriusPath){
-		
-		IFile dslFile = getDslFileFromProject(project);
-		Resource res = (new ResourceSetImpl()).getResource(URI.createURI(dslFile.getFullPath().toOSString()), true);
-		Dsl dsl = (Dsl) res.getContents().get(0);
-		
-		Optional<Entry> sirius = dsl.getEntries()
-			.stream()
-			.filter(entry -> entry.getKey().equals("sirius"))
-			.findFirst();
-		if(sirius.isPresent()) {
-			sirius.get().setValue(siriusPath);
-		}
-		else {
-			Entry siriusEntry = ((DslFactory)DslPackage.eINSTANCE.getEFactoryInstance()).createEntry();
-			siriusEntry.setKey("sirius");
-			siriusEntry.setValue(siriusPath);
-			dsl.getEntries().add(siriusEntry);
-		}
-		try {
-			res.save(Collections.emptyMap());
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
-	
-	protected void waitForAutoBuild() {
-		boolean wasInterrupted = false;
-		do {
-			try {
-				Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD,	null);
-				wasInterrupted = false;
-			} catch (OperationCanceledException e) {
-				Activator.warn(e.getMessage(), e);
-			} catch (InterruptedException e) {
-				wasInterrupted = true;
-			}
-		} while (wasInterrupted);
-	}
 }

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/editor/CreateDSAProposal.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/editor/CreateDSAProposal.java
@@ -34,7 +34,7 @@ import org.eclipse.gemoc.commons.eclipse.pde.wizards.pages.pde.TemplateListSelec
 import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.Activator;
 import org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.SequentialSingleLanguageTemplate;
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.PlatformUI;
@@ -146,7 +146,7 @@ public class CreateDSAProposal implements IProposal{
 			Language lang = (Language) context;
 			this.packageName = ((ModelTypingSpace)lang.eContainer()).getName().toLowerCase();
 			this.languageName = lang.getName().toLowerCase();
-			this.ecoreFile = MelangeXDSMLProjectHelper.getFirstEcore(lang);
+			this.ecoreFile = XDSMLProjectHelper.getFirstEcore(lang);
 		}
 	}
 	

--- a/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/wizards/CreateDSAWizardContextActionDSAK3.java
+++ b/java_execution/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/wizards/CreateDSAWizardContextActionDSAK3.java
@@ -33,7 +33,7 @@ import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.Activator;
 import org.eclipse.gemoc.executionframework.ui.xdsml.activefile.ActiveFile;
 import org.eclipse.gemoc.executionframework.ui.xdsml.activefile.ActiveFileEcore;
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 
 import fr.inria.diverse.k3.ui.wizards.NewK3ProjectWizard;
 import fr.inria.diverse.k3.ui.wizards.pages.NewK3ProjectWizardFields.KindsOfProject;
@@ -93,7 +93,7 @@ public class CreateDSAWizardContextActionDSAK3 extends CreateDSAWizardContextBas
 				
 				wd.create();
 
-				k3Wizard.getPageProject().setProjectName(MelangeXDSMLProjectHelper.baseProjectName(_gemocLanguageIProject)+".k3dsa");
+				k3Wizard.getPageProject().setProjectName(XDSMLProjectHelper.baseProjectName(_gemocLanguageIProject)+".k3dsa");
 				k3Wizard.getPageProject().setProjectKind(KindsOfProject.PLUGIN);
 				// set field as much as possible
 				

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Require-Bundle: com.google.guava,
  org.eclipse.gemoc.opsemanticsview.model;bundle-version="0.1.0",
  org.eclipse.gemoc.opsemanticsview.gen;bundle-version="1.0.0",
  org.jdom2;bundle-version="2.0.6",
- org.eclipse.gemoc.dsl
+ org.eclipse.gemoc.dsl,
+ org.eclipse.gemoc.xdsmlframework.ui.utils;bundle-version="4.0.0"
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.trace.gemoc.generator,

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/src/org/eclipse/gemoc/trace/gemoc/generator/TraceAddonGeneratorIntegration.xtend
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.generator/src/org/eclipse/gemoc/trace/gemoc/generator/TraceAddonGeneratorIntegration.xtend
@@ -23,11 +23,11 @@ import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Platform
 import org.eclipse.core.runtime.Status
 import org.eclipse.gemoc.opsemanticsview.gen.OperationalSemanticsViewGenerator
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.common.util.URI
 import org.eclipse.gemoc.dsl.Dsl
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper
 
 /**
  * Plenty of ways to call the generator in an eclipse context.
@@ -38,7 +38,7 @@ class TraceAddonGeneratorIntegration {
 	static def void generateAddon(IFile melangeFile, String selectedLanguage, boolean replace,
 		IProgressMonitor monitor) {
 		// Computing output plugin name
-		val pluginName = MelangeXDSMLProjectHelper.baseProjectName(melangeFile.project) + "." +
+		val pluginName = XDSMLProjectHelper.baseProjectName(melangeFile.project) + "." +
 			selectedLanguage.toLowerCase + ".trace"
 		generateAddon(melangeFile, selectedLanguage, pluginName, replace, monitor)
 	}
@@ -61,7 +61,7 @@ class TraceAddonGeneratorIntegration {
 		]
 
 		// If we find one, we generate
-		if (validViewGenerator != null) {
+		if (validViewGenerator !== null) {
 			val OperationalSemanticsView mmextension = validViewGenerator.generate(selection, dslFile.project);
 			generateAddon(selectedLanguage, pluginName, replace, monitor, mmextension)
 
@@ -81,7 +81,7 @@ class TraceAddonGeneratorIntegration {
 	/**
 	 * Central operation of the class, that calls business operations
 	 */
-	public static def void generateAddon(String mmName, String pluginName, boolean replace, IProgressMonitor monitor,
+	static def void generateAddon(String mmName, String pluginName, boolean replace, IProgressMonitor monitor,
 		OperationalSemanticsView executionExtension) throws CoreException {
 
 		// We look for an existing project with this name
@@ -93,7 +93,7 @@ class TraceAddonGeneratorIntegration {
 			if (replace) {
 				// existingProject.delete(true, monitor);
 				val WorkspaceJob job = new WorkspaceJob("deleting project " + existingProject.name + " content") {
-					override public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+					override IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 						for (IResource iRes : existingProject.members) {
 							if (!(iRes.name.equals(".project") || iRes.name.equals(".classpath"))) {
 								iRes.delete(true, monitor);

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/src/org/eclipse/gemoc/trace/gemoc/ui/commands/XDSMLProject2TraceAddonHandler.xtend
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc.ui/src/org/eclipse/gemoc/trace/gemoc/ui/commands/XDSMLProject2TraceAddonHandler.xtend
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.trace.gemoc.ui.commands
 
-import org.eclipse.gemoc.trace.gemoc.generator.TraceAddonGeneratorIntegration
 import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.core.commands.ExecutionException
 import org.eclipse.core.commands.IHandler
@@ -19,10 +18,11 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.Status
 import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.gemoc.trace.gemoc.generator.TraceAddonGeneratorIntegration
+import org.eclipse.gemoc.xdsmlframework.ide.ui.commands.AbstractDslSelectHandler
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper
 import org.eclipse.jface.dialogs.InputDialog
 import org.eclipse.jface.window.Window
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper
-import org.eclipse.gemoc.xdsmlframework.ide.ui.commands.AbstractDslSelectHandler
 
 /**
  * Handler that allows to get an XDSML project (containing a melange file) 
@@ -35,7 +35,7 @@ class XDSMLProject2TraceAddonHandler extends AbstractDslSelectHandler implements
 		String language) throws ExecutionException {
 
 		val IFile dslFile = getDslFileFromSelection(event);
-		val baseProjectName = MelangeXDSMLProjectHelper.baseProjectName(dslFile.project)
+		val baseProjectName = XDSMLProjectHelper.baseProjectName(dslFile.project)
 
 		// If the base project name doesn't end with the language name, we suggest it		
 		val suggestedBasePluginName = if (baseProjectName.endsWith(language.toLowerCase))


### PR DESCRIPTION
This PR fixes https://github.com/eclipse/gemoc-studio-modeldebugging/issues/50 so we can create Sirius specification project using the popup menu on GEMOC project.

This PR also improves the wizard by:
- add a new field that keeps the dsl file information
- allow to directly call the wizard from the _File > new_ menu
- enable templates contribution. So one can provide a template plugin that complements the odesign file with extra behavior.
- the code that update the .dsl file has been moved from the handler class to the wizard class.

This PR also re-enable system tests that check that we can open this wizard


This PR comes with https://github.com/eclipse/gemoc-studio/pull/156