### PR TITLE
Clarifies Eclipse consoles used by the engines

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/src/org/eclipse/gemoc/executionframework/debugger/Activator.java
@@ -96,7 +96,11 @@ public class Activator extends GemocPlugin {
 		if (_loggingBackend == null) {
 			_loggingBackend = new DefaultLoggingBackend(this);
 			MessagingSystemManager msm = new MessagingSystemManager();
-			MessagingSystem ms = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "Model Debugger console");
+			// use the baseMessageGroup of the engine in order to share consoles instead of duplicating them
+			// however do not use shared static string to avoid direct dependency 
+			MessagingSystem ms = msm.createBestPlatformMessagingSystem(
+					"org.eclipse.gemoc.executionframework.engine", 
+					"Modeling Workbench Console");
 			_loggingBackend.setMessagingSystem(ms);
 		}
 		return _loggingBackend;

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/Activator.java
@@ -25,6 +25,8 @@ public class Activator extends GemocPlugin {
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.gemoc.executionframework.engine"; //$NON-NLS-1$
+	
+	public static final String CONSOLE_NAME = "Modeling Workbench Console";
 
 	// The shared instance
 	private static Activator plugin;
@@ -92,7 +94,7 @@ public class Activator extends GemocPlugin {
 		{
 			_loggingBackend = new DefaultLoggingBackend(this);
 			MessagingSystemManager msm = new MessagingSystemManager();
-			MessagingSystem ms = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "Execution Engine");
+			MessagingSystem ms = msm.createBestPlatformMessagingSystem(PLUGIN_ID, CONSOLE_NAME);
 			_loggingBackend.setMessagingSystem(ms);
 		}
 		return _loggingBackend;

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.commons.eclipse.ui,
  org.eclipse.swt,
  org.eclipse.ui.workbench,
- org.eclipse.gemoc.dsl.model
+ org.eclipse.gemoc.dsl.model,
+ org.eclipse.gemoc.executionframework.engine;bundle-version="4.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.sirius,

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
@@ -36,7 +36,9 @@ public class Activator extends AbstractUIPlugin {
 		if (messagingSystem == null) 
 		{
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messagingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "Modeling Workbench Console");
+			messagingSystem = msm.createBestPlatformMessagingSystem(
+				org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+				org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 			if (messagingSystem instanceof EclipseMessagingSystem)
 				((EclipseMessagingSystem) messagingSystem).setConsoleLogLevel(ConsoleLogLevel.DEV_DEBUG);
 		}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/Activator.java
@@ -36,7 +36,7 @@ public class Activator extends AbstractUIPlugin {
 		if (messagingSystem == null) 
 		{
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messagingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "Execution Engine");
+			messagingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "Modeling Workbench Console");
 			if (messagingSystem instanceof EclipseMessagingSystem)
 				((EclipseMessagingSystem) messagingSystem).setConsoleLogLevel(ConsoleLogLevel.DEV_DEBUG);
 		}

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/Activator.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/Activator.java
@@ -99,8 +99,8 @@ public class Activator extends AbstractUIPlugin {
 		if (messaggingSystem == null) {
 			MessagingSystemManager msm = new MessagingSystemManager();
 			messaggingSystem = msm.createBestPlatformMessagingSystem(
-					org.eclipse.gemoc.executionframework.debugger.Activator.PLUGIN_ID, 
-					"Model Debugger console");
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messaggingSystem;
 	}


### PR DESCRIPTION
This PR clarifies the use of various Eclipse consoles used by the engines.

It makes sure to use a unique console for most engines messages.
The name for this console is currently *Modeling Workbench Console*

This PR comes with several other PR: https://github.com/eclipse/gemoc-studio-execution-moccml/pull/17 https://github.com/eclipse/gemoc-studio-execution-ale/pull/20
