### PR TITLE
Fix double instantiation of language specific addons

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DefaultExecutionPlatform.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DefaultExecutionPlatform.java
@@ -29,11 +29,12 @@ public class DefaultExecutionPlatform implements IExecutionPlatform {
 
 	public DefaultExecutionPlatform(LanguageDefinitionExtension _languageDefinition, IRunConfiguration runConfiguration) throws CoreException {
 		_modelLoader = _languageDefinition.instanciateModelLoader();
-		_addons = _languageDefinition.instanciateEngineAddons();
+		_addons = new ArrayList<IEngineAddon>();
 
 		for (EngineAddonSpecificationExtension extension : runConfiguration.getEngineAddonExtensions()) {
 			addEngineAddon(extension.instanciateComponent());
 		}
+		//addons defined specifically for the language
 		for (IEngineAddon addon : _languageDefinition.instanciateEngineAddons()) {
 			addEngineAddon(addon);
 		}


### PR DESCRIPTION
When using a language specific addon, this addon was instantiated twice.

This was causing: cpu overhead (due to addon code called twice on every step), and raise 2 UI in case of addon opening a JFrame for example.

This PR fixes this.
