### PR TITLE
Tycho 1.5 and p2 dependencies optimisation

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.1</version>
   </extension>
 </extensions>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -1,20 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
-    <artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
-    <packaging>pom</packaging>    
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.gemoc.modeldebugging.framework</groupId>
+	<artifactId>org.eclipse.gemoc.modeldebugging.framework.root</artifactId>
+	<version>4.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-    	<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	
-    <modules>    
-        <module>execution_framework</module>
-        <module>framework_commons</module>       
-        <module>xdsml_framework</module>
-    </modules>
+
+	<modules>
+		<module>execution_framework</module>
+		<module>framework_commons</module>
+		<module>xdsml_framework</module>
+	</modules>
+
+	<repositories>
+		<repository>
+			<id>Eclipse release</id>
+			<layout>p2</layout>
+			<url>${eclipse.release.p2.url}</url>
+		</repository>
+		<repository>
+			<id>K3</id>
+			<layout>p2</layout>
+			<url>${k3.p2.url}</url>
+		</repository>
+		<repository>
+			<id>Melange</id>
+			<layout>p2</layout>
+			<url>${melange.p2.url}</url>
+		</repository>
+		<!-- <repository> -->
+		<!-- <id>ELK</id> -->
+		<!-- <layout>p2</layout> -->
+		<!-- <url>${elk.p2.url}</url> -->
+		<!-- </repository> -->
+		<!-- <repository> -->
+		<!-- <id>AspectJ</id> -->
+		<!-- <layout>p2</layout> -->
+		<!-- <url>${aspectJ.p2.url}</url> -->
+		<!-- </repository> -->
+	</repositories>
 </project>

--- a/java_execution/pom.xml
+++ b/java_execution/pom.xml
@@ -49,11 +49,6 @@
             <url>${elk.p2.url}</url>
     	</repository>
     	<repository>
-    		<id>APP4MC</id>
-            <layout>p2</layout>
-            <url>${app4mc.p2.url}</url>
-    	</repository>
-    	<repository>
     		<id>AspectJ</id>
             <layout>p2</layout>
             <url>${aspectJ.p2.url}</url>

--- a/java_execution/pom.xml
+++ b/java_execution/pom.xml
@@ -27,5 +27,37 @@
         
     </modules>
 
+    <repositories>
+    	<repository>
+    		<id>Eclipse release</id>
+            <layout>p2</layout>
+            <url>${eclipse.release.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>K3</id>
+            <layout>p2</layout>
+            <url>${k3.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>Melange</id>
+            <layout>p2</layout>
+            <url>${melange.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>ELK</id>
+            <layout>p2</layout>
+            <url>${elk.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>APP4MC</id>
+            <layout>p2</layout>
+            <url>${app4mc.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>AspectJ</id>
+            <layout>p2</layout>
+            <url>${aspectJ.p2.url}</url>
+    	</repository>
+    </repositories>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,80 +27,19 @@
 	</modules>
 
     <properties>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.5.1</tycho-version>
     	<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
-		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->		
+		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->	
+		
+		<eclipse.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.release.p2.url>
+		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
+		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2018-12-03/</melange.p2.url>
+		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
+		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
+			
 	</properties>
-	
-  	<repositories>
-  	<!-- List of P2 repositories of external tool used to build the components -->
-  	<!--  must NOT include the repositories of the tools included in the Studio has it has its own complementary list -->
-
-		<repository>
-            <id>Photon release</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/photon</url>
-        </repository>
-        <repository>
-            <id>kermeta-3</id>
-            <layout>p2</layout>
-            <url>http://www.kermeta.org/k3/update_2018-09-05</url>
-        </repository>
-        <repository>
-            <id>melange</id>
-            <layout>p2</layout>
-            <url>http://melange.inria.fr/updatesite/nightly/update_2018-12-03/</url>
-        </repository>
-        <repository>
-            <id>elk</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/elk/updates/releases/0.4.1/</url>
-        </repository>
-        <repository>
-            <id>Sirius</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/sirius/updates/releases/6.0.1/photon/</url>
-        </repository>
-<!--         <repository> -->
-<!--             <id>umldesigner</id> -->
-<!--             <layout>p2</layout> -->
-<!--             <url>http://releases.umldesigner.org/5.0.0/repository/</url> -->
-<!--         </repository> -->
-        <repository>
-            <id>nebula</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/nebula/snapshot/</url>
-        </repository>
-        <repository> <!-- this repo is used to provide jdom and jaxen plugins -->
-            <id>app4mc</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1/</url>
-        </repository>
-	    <repository>
-            <id>AspectJ</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/tools/ajdt/48/dev/update</url>
-        </repository>
-        <!-- <repository>
-            <id>javafx</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/efxclipse/updates-released/2.1.0/site</url>
-        </repository>-->
-<!--          <repository> -->
-<!-- 			<id>efxclipse-repo</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>http://download.eclipse.org/efxclipse/runtime-nightly/site</url> -->
-<!-- 		</repository> -->
-<!-- 		<repository> -->
-<!-- 			<id>efxclipse-addons</id> -->
-<!-- 			<layout>p2</layout> -->
-<!-- 			<url>http://downloads.efxclipse.org/efxclipse.bestsolution.at/p2-repos/addons/nightly/site/</url> -->
-<!-- 		</repository>  -->
-		    
-    </repositories>
-
 
 	<build>
 		<plugins>
@@ -250,6 +189,13 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
+				<!-- 	<target>
+                     <artifact>
+                         <groupId>org.eclipse.gemoc</groupId>
+                         <artifactId>org.eclipse.gemoc.modeldebugging.target-platform</artifactId>
+                         <version>3.0.0-SNAPSHOT</version>
+                     </artifact>
+                 </target>-->
 				</configuration>
 			</plugin>
 			<plugin>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -36,11 +36,6 @@
             <url>${elk.p2.url}</url>
     	</repository>
     	<repository>
-    		<id>APP4MC</id>
-            <layout>p2</layout>
-            <url>${app4mc.p2.url}</url>
-    	</repository>
-    	<repository>
     		<id>AspectJ</id>
             <layout>p2</layout>
             <url>${aspectJ.p2.url}</url>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -12,9 +12,38 @@
         <relativePath>..</relativePath>
 	</parent>
     <modules>
-       
         <module>org.eclipse.gemoc.modeldebugging.feature</module>
-        
     </modules>
-	
+	<repositories>
+    	<repository>
+    		<id>Eclipse release</id>
+            <layout>p2</layout>
+            <url>${eclipse.release.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>K3</id>
+            <layout>p2</layout>
+            <url>${k3.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>Melange</id>
+            <layout>p2</layout>
+            <url>${melange.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>ELK</id>
+            <layout>p2</layout>
+            <url>${elk.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>APP4MC</id>
+            <layout>p2</layout>
+            <url>${app4mc.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>AspectJ</id>
+            <layout>p2</layout>
+            <url>${aspectJ.p2.url}</url>
+    	</repository>
+    </repositories>
 </project>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.5.1</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 
@@ -48,7 +48,6 @@
 		<module>releng/org.eclipse.gemoc.dsl.debug.ui.feature</module>
 		<module>releng/org.eclipse.gemoc.dsl.debug.sirius.ui.feature</module>
 	</modules>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -84,6 +83,13 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
+<!-- 					<target> -->
+<!-- 	                     <artifact> -->
+<!-- 	                         <groupId>org.eclipse.gemoc</groupId> -->
+<!-- 	                         <artifactId>org.eclipse.gemoc.modeldebugging.target-platform</artifactId> -->
+<!-- 	                         <version>3.0.0-SNAPSHOT</version> -->
+<!-- 	                     </artifact> -->
+<!-- 	                 </target> -->
 					<target>
 						<artifact>
 							<groupId>${project.groupId}</groupId>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -96,7 +96,7 @@
 							<artifactId>${project.artifactId}</artifactId>
 							<version>${project.version}</version>
 							<classifier>
-								../../releng/org.eclipse.gemoc.dsl.debug.target/dsldebug-oxygen
+								../../releng/org.eclipse.gemoc.dsl.debug.target/dsldebug-photon
 							</classifier>
 						</artifact>
 					</target>

--- a/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.target/dsldebug-photon.target
+++ b/simulationmodelanimation/releng/org.eclipse.gemoc.dsl.debug.target/dsldebug-photon.target
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="dsldebug_oxygen" sequenceNumber="1441958326">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.edit.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.ecore.editor.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.transaction.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.edit.ui.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="0.0.0"/>
+      <unit id="com.google.guava" version="0.0.0"/>
+      <unit id="org.junit" version="0.0.0"/>
+      <repository id="Eclipse-Photon" location="http://download.eclipse.org/releases/photon/201806271001"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sirius.runtime.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.sirius.runtime.acceleo.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="0.0.0"/>
+      <repository id="Sirius" location="http://download.eclipse.org/sirius/updates/releases/6.0.2/photon"/>
+    </location>
+  </locations>
+</target>

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -17,4 +17,27 @@
         <module>generator</module>       
         <module>manager</module>
     </modules>
+    
+    <repositories>
+    	<repository>
+    		<id>Eclipse release</id>
+            <layout>p2</layout>
+            <url>${eclipse.release.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>K3</id>
+            <layout>p2</layout>
+            <url>${k3.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>Melange</id>
+            <layout>p2</layout>
+            <url>${melange.p2.url}</url>
+    	</repository>
+    	<repository>
+    		<id>ELK</id>
+            <layout>p2</layout>
+            <url>${elk.p2.url}</url>
+    	</repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Companion PR of https://github.com/eclipse/gemoc-studio/pull/189

This PR tries to optimize the build time on the CI with the following changes:

- update tycho from 1.2.0 to 1.5.1
- remove p2 repository APP4MC 
- remove use of eclipse oxygen p2 in dsl.debug