### PR TITLE
Improve test video recording

### DIFF
--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -32,7 +32,7 @@ public class GEMOCTestVideoHelper {
 	 * relative path to the log file
 	 * this is relative to the environment variable "WORKSPACE"  that is usually set be JENKINS
 	 */
-	public static String LOGFILEPATH = "gemoc_studio/dev_support/full_compilation/target/system_test_timeline.log";
+	public static String LOGFILEPATH = "gemoc-studio/dev_support/full_compilation/target/system_test_timeline.log";
 	
 	/**
 	 * if the file LOGFILENAME exists, then it reads the first line in order to get the test start time stamp

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -54,8 +54,8 @@ public class GEMOCTestVideoHelper {
 						videoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
 				
 				// print in the log file and in the system.out (for junit capture)
-				printwriter.println(""+String.format("%1$13s", duration) +" | " + currentDate + " | "+msg);
-				System.out.println(""+String.format("%1$13s", duration) +" | " + currentDate + " | "+msg);
+				printwriter.println(""+String.format("%1$14s", duration) +" | " + currentDate + " | "+msg);
+				System.out.println(""+String.format("%1$14s", duration) +" | " + currentDate + " | "+msg);
 			}
 		} catch (IOException | ParseException e) {
 			e.printStackTrace();

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -41,7 +41,11 @@ public class GEMOCTestVideoHelper {
 	 */
 	public static void addTestSuiteVideoLog(String msg) {
 		File file = getVideoTimeStampFile();
-		if(!file.exists()) return;
+		if(!file.exists()) {
+			System.out.println("ignoring addTestSuiteVideoLog");
+			System.out.println(file.getPath()+ " not found");
+			return;
+		}
 		try {
 			Date videoStartDate = readTimeStamp();
 			try(PrintWriter printwriter = new PrintWriter(new FileWriter(file, true))){

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -53,7 +53,7 @@ public class GEMOCTestVideoHelper {
 				Duration duration = Duration.between(currentDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
 						videoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
 				
-				printwriter.println(""+duration +" | " + currentDate + " | "+msg);
+				printwriter.println(""+String.format("%1$13s", duration) +" | " + currentDate + " | "+msg);
 			}
 		} catch (IOException | ParseException e) {
 			e.printStackTrace();

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Inria.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.test.lib;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Date;
+
+/**
+ * Provides some helper methods to enhance information provided by the video recording of UI Tests
+ *
+ */
+public class GEMOCTestVideoHelper {
+
+	/**
+	 * relative path to the log file
+	 * this is relative to the current user dir
+	 */
+	public static String LOGFILEPATH = "../../../dev_support/full_compilation/target/system_test_timeline.log";
+	
+	/**
+	 * if the file LOGFILENAME exists, then it reads the first line in order to get the test start time stamp
+	 * It then add a new line indicating the duration since this time stamp (allowing to navigate in the 
+	 * corresponding video of this amount of time) and the name of the test suite
+	 */
+	public static void addTestSuiteVideoLog(String msg) {
+		File file = getVideoTimeStampFile();
+		if(!file.exists()) return;
+		try {
+			Date videoStartDate = readTimeStamp();
+			try(PrintWriter printwriter = new PrintWriter(new FileWriter(file, true))){
+				Date currentDate = new Date();
+				Duration duration = Duration.between(currentDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
+						videoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+				
+				printwriter.println(""+duration +" | " + currentDate + " | "+msg);
+			}
+		} catch (IOException | ParseException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
+	public static Date readTimeStamp() throws IOException, ParseException { 
+		try (
+				FileReader fr=new FileReader(getVideoTimeStampFile());    //reads the file  
+				BufferedReader br=new BufferedReader(fr)) {  //creates a buffering character input stream  
+			String line=br.readLine(); 
+			if(line!=null)  
+			{     
+				//date --iso-8601=s     
+				//2019-11-26T10:57:45+01:00
+				SimpleDateFormat sdf = new SimpleDateFormat ("yyyy-MM-dd'T'HH:mm:ssXXX");
+				return sdf.parse(line);
+			}
+		}
+		return null;
+	}
+	
+	public static File getVideoTimeStampFile() {
+		
+		File file=new File(System.getProperty("user.dir")+"/"+LOGFILEPATH);
+		return file;
+	}
+	
+}

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -30,9 +30,9 @@ public class GEMOCTestVideoHelper {
 
 	/**
 	 * relative path to the log file
-	 * this is relative to the current user dir
+	 * this is relative to the environment variable "WORKSPACE"  that is usually set be JENKINS
 	 */
-	public static String LOGFILEPATH = "../../../dev_support/full_compilation/target/system_test_timeline.log";
+	public static String LOGFILEPATH = "gemoc_studio/dev_support/full_compilation/target/system_test_timeline.log";
 	
 	/**
 	 * if the file LOGFILENAME exists, then it reads the first line in order to get the test start time stamp
@@ -75,7 +75,9 @@ public class GEMOCTestVideoHelper {
 	
 	public static File getVideoTimeStampFile() {
 		
-		File file=new File(System.getProperty("user.dir")+"/"+LOGFILEPATH);
+		// search the git root using the JENKINS environment variable
+		String jenkinsWorkspaceDir = System.getProperty("WORKSPACE");
+		File file=new File(jenkinsWorkspaceDir+"/"+LOGFILEPATH);
 		return file;
 	}
 	

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -53,7 +53,9 @@ public class GEMOCTestVideoHelper {
 				Duration duration = Duration.between(currentDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
 						videoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
 				
+				// print in the log file and in the system.out (for junit capture)
 				printwriter.println(""+String.format("%1$13s", duration) +" | " + currentDate + " | "+msg);
+				System.out.println(""+String.format("%1$13s", duration) +" | " + currentDate + " | "+msg);
 			}
 		} catch (IOException | ParseException e) {
 			e.printStackTrace();

--- a/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
+++ b/framework/xdsml_framework/tests/org.eclipse.gemoc.xdsmlframework.test.lib/src/org/eclipse/gemoc/xdsmlframework/test/lib/GEMOCTestVideoHelper.java
@@ -56,7 +56,6 @@ public class GEMOCTestVideoHelper {
 				printwriter.println(""+duration +" | " + currentDate + " | "+msg);
 			}
 		} catch (IOException | ParseException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 	}
@@ -68,9 +67,9 @@ public class GEMOCTestVideoHelper {
 			String line=br.readLine(); 
 			if(line!=null)  
 			{     
-				//date --iso-8601=s     
-				//2019-11-26T10:57:45+01:00
-				SimpleDateFormat sdf = new SimpleDateFormat ("yyyy-MM-dd'T'HH:mm:ssXXX");
+				//date --rfc-3339=s     
+				//2019-11-29 09:43:30+00:00
+				SimpleDateFormat sdf = new SimpleDateFormat ("yyyy-MM-dd HH:mm:ssXXX");
 				return sdf.parse(line);
 			}
 		}


### PR DESCRIPTION
Companion PR of https://github.com/eclipse/gemoc-studio/pull/190

This PR contributes a helper class that allows writing a log file that is aware of the start of the video recording.

In the Eclipse CI, the UI tests are now recorded in an mp4 video (ex: https://ci.eclipse.org/gemoc/job/gemoc-studio-integration/job/master/lastSuccessfulBuild/artifact/gemoc-studio/dev_support/full_compilation/target/)

This PR adds a log file in this folder with an indication of the time spent since the start of the video.

The language workbench and modelling tests contribute to this by adding a call to the helper class in the `@beforeClass` and the `@setup` 

This produce logs such as:
```
2019-11-29 14:57:11+00:00
PT-1M-56.062S | Fri Nov 29 14:59:07 UTC 2019 | starting org.eclipse.gemoc.studio.tests.system.lwb.feature.XDSMLPerspective_Test
 PT-2M-5.139S | Fri Nov 29 14:59:16 UTC 2019 |    - test01_FileMenuContent
 PT-2M-9.384S | Fri Nov 29 14:59:20 UTC 2019 |    - test02_toolbarDropDownNewMenuContent
PT-2M-42.386S | Fri Nov 29 14:59:53 UTC 2019 |    - test03_toolbarContent
PT-2M-55.961S | Fri Nov 29 15:00:06 UTC 2019 | starting org.eclipse.gemoc.studio.tests.system.lwb.feature.GenerateTrace4OfficialExampleMelangeK3FSM_Test
 PT-3M-0.463S | Fri Nov 29 15:00:11 UTC 2019 |    - test01GenerateTrace_usingDirectCommand_NoErrorsInWorkspace
PT-4M-38.725S | Fri Nov 29 15:01:49 UTC 2019 | starting org.eclipse.gemoc.studio.tests.system.lwb.feature.GenerateLangRuntime4OfficialExampleMelangeK3FSM_Test
PT-6M-50.681S | Fri Nov 29 15:04:01 UTC 2019 | starting org.eclipse.gemoc.studio.tests.system.lwb.userstory.DeployOfficialExampleMelangeK3FSM_Test
PT-6M-53.949S | Fri Nov 29 15:04:04 UTC 2019 |    - test01_InstallMelangeK3Fsm
PT-7M-28.219S | Fri Nov 29 15:04:39 UTC 2019 | starting org.eclipse.gemoc.studio.tests.system.lwb.userstory.CreateSingleSequentialLanguageFromOfficialFSM_Test
PT-7M-43.247S | Fri Nov 29 15:04:54 UTC 2019 |    - test01_OpenXDSMLPerspective
PT-7M-48.577S | Fri Nov 29 15:04:59 UTC 2019 |    - test02_CreateSequentialLanguageProject
 PT-8M-9.652S | Fri Nov 29 15:05:20 UTC 2019 |    - test04_CreateTraceAddon
PT-8M-28.237S | Fri Nov 29 15:05:39 UTC 2019 |    - test05_CreateSiriusEditorForLanguage
```

where the first column indicates the duration since the beginning of the video

I hope it will help us debug the flaky tests (https://github.com/eclipse/gemoc-studio/issues/123)