### PR TITLE
Fix xdsmlFilePath attribute in plugin.xml

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DslHelper.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/DslHelper.java
@@ -57,6 +57,12 @@ public class DslHelper {
 		return languagesNames;
 	}
 
+	/**
+	 * Load the language from installed languages
+	 * converts the xdsmlFilePath into platform:/plugin/ URI
+	 * @param languageName
+	 * @return the root element of the dsl model
+	 */
 	public static Dsl load(String languageName) {
 
 		IConfigurationElement[] languages = Platform.getExtensionRegistry().getConfigurationElementsFor(LanguageDefinitionExtensionPoint.GEMOC_LANGUAGE_EXTENSION_POINT);
@@ -64,7 +70,8 @@ public class DslHelper {
 			String xdsmlPath = lang.getAttribute("xdsmlFilePath");
 			String xdsmlName = lang.getAttribute("name");
 			if (xdsmlName.equals(languageName) && xdsmlPath.endsWith(".dsl")) {
-				Resource res = (new ResourceSetImpl()).getResource(URI.createURI(xdsmlPath), true);
+				URI xdsmlURI = xdsmlPath.startsWith("platform:/") ? URI.createURI(xdsmlPath) : URI.createPlatformPluginURI(xdsmlPath, true);
+				Resource res = (new ResourceSetImpl()).getResource(xdsmlURI, true);
 				Dsl dsl = (Dsl) res.getContents().get(0);
 				return dsl;
 			}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/builder/GemocLanguageProjectBuilder.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.ide.ui/src/org/eclipse/gemoc/xdsmlframework/ide/ui/builder/GemocLanguageProjectBuilder.java
@@ -189,7 +189,7 @@ public class GemocLanguageProjectBuilder extends IncrementalProjectBuilder {
 		helper.updateXDSMLDefinitionInExtensionPoint(gemocExtensionPoint, languageName);
 		helper.updateXDSMLDefinitionAttributeInExtensionPoint(gemocExtensionPoint,
 				LanguageDefinitionExtensionPoint.GEMOC_LANGUAGE_EXTENSION_POINT_XDSML_DEF_XDSML_FILE_PATH_ATT,
-				"platform:/plugin/" + project.getName() + "/" + dslFile.getProjectRelativePath());
+				dslFile.getFullPath().toString());
 		helper.saveDocument(pluginfile);
 	}
 	


### PR DESCRIPTION
fix https://github.com/eclipse/gemoc-studio-modeldebugging/issues/137

the xdsmlFilePath attribute in plugin.xml now contains a path and not a URI