### PR TITLE
Handle Sirius forced resource set

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
@@ -165,14 +165,26 @@ public class DefaultModelLoader implements IModelLoader {
 			try {
 				// Killing + restarting Sirius session for animation
 				killPreviousSiriusSession(context.getRunConfiguration().getAnimatorURI());
-				openNewSiriusSession(context, context.getRunConfiguration().getAnimatorURI(), resourceSet, modelURI,
+				Session session = openNewSiriusSession(context, context.getRunConfiguration().getAnimatorURI(), resourceSet, modelURI,
 						subMonitor,nsURIMapping);
-
 				// At this point Sirius has loaded the model, we just need to
 				// find it
-				for (Resource r : resourceSet.getResources()) {
-					if (r.getURI().equals(modelURI)) {
-						return r;
+				if(session.getTransactionalEditingDomain().getResourceSet() != resourceSet) {
+					// the session has created a different resourceSet than the one we provided
+					//we need to use the resource from it instead of the one from our resourceSet
+					// TODO check if this is still compatible with melange
+					// TODO maybe some simplification is possible !
+
+					for (Resource r : session.getTransactionalEditingDomain().getResourceSet().getResources()) {
+						if (r.getURI().equals(modelURI)) {
+							return r;
+						}
+					}
+				} else {
+					for (Resource r : resourceSet.getResources()) {
+						if (r.getURI().equals(modelURI)) {
+							return r;
+						}
 					}
 				}
 			} catch (CoreException e) {

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DefaultModelLoader.java
@@ -174,7 +174,9 @@ public class DefaultModelLoader implements IModelLoader {
 					//we need to use the resource from it instead of the one from our resourceSet
 					// TODO check if this is still compatible with melange
 					// TODO maybe some simplification is possible !
-
+					if(useMelange) {
+						Activator.getDefault().getLog().log(new Status(IStatus.WARNING, Activator.PLUGIN_ID, "Sirius Session returned a new ResourceSet and you are using a melange query, this scenario has not been validated yet", new Exception()));
+					}
 					for (Resource r : session.getTransactionalEditingDomain().getResourceSet().getResources()) {
 						if (r.getURI().equals(modelURI)) {
 							return r;


### PR DESCRIPTION
With some models, Sirius session returns a new resourceSet instead of using the one we provided in the DefaultModelLoader.  (ex: Capella)

This ends up with 2 different resources, one for the execution and one for the animation.

This PR makes sure to get a single resource  (the one create by the sirius session)

However, I'm not sure this can also handle melange query (ie. "downcasting" model) so I added a warning if this situation occurs while using melange queries.