### PR TITLE
Add information about number of completed steps in the EngineStatus class

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -451,7 +451,7 @@ public abstract class AbstractExecutionEngine<C extends IExecutionContext<R, ?, 
 	 * step was done through a RecordingCommand, it can be given.
 	 */
 	protected final void beforeExecutionStep(Step<?> step, RecordingCommand rc) {
-
+		engineStatus.incrementNbLogicalStepCalled();
 		try {
 
 			currentSteps.push(step);

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
@@ -256,7 +256,9 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 						break;
 					}
 					result += "\n";
-					result += "Step " + engine.getEngineStatus().getNbLogicalStepRun();
+					long runSteps = engine.getEngineStatus().getNbLogicalStepRun();
+					long notCompletedSteps = engine.getEngineStatus().getNbLogicalStepCalled() - runSteps;
+					result += String.format("Steps (Completed[NotCompleted]): %d[%d]", runSteps, notCompletedSteps);
 				}
 				return result;
 			}
@@ -273,7 +275,9 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 				String result = "";
 				if (element instanceof IExecutionEngine) {
 					IExecutionEngine<?> engine = (IExecutionEngine<?>) element;
-					result = String.format("%d", engine.getEngineStatus().getNbLogicalStepRun());
+					long runSteps = engine.getEngineStatus().getNbLogicalStepRun();
+					long notCompletedSteps = engine.getEngineStatus().getNbLogicalStepCalled() - runSteps;
+					result = String.format("%d[%d]", runSteps, notCompletedSteps);
 				}
 				return result;
 			}
@@ -379,7 +383,8 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 	}
 
 	@Override
-	public void aboutToExecuteStep(IExecutionEngine<?> executionEngine, Step<?> logicalStepToApply) {
+	public void aboutToExecuteStep(IExecutionEngine<?> engine, Step<?> logicalStepToApply) {
+		reselectEngine(engine);
 	}
 
 	@Override

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/EngineStatus.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/EngineStatus.java
@@ -17,6 +17,7 @@ import org.eclipse.gemoc.trace.commons.model.trace.Step;
  *
  */
 public class  EngineStatus {
+	long nbLogicalStepCalled = 0;
 	long nbLogicalStepRun = 0;
 	
 	Step<?> chosenLogicalStep;
@@ -51,6 +52,27 @@ public class  EngineStatus {
 	public void incrementNbLogicalStepRun() {
 		this.nbLogicalStepRun +=1;
 	}
-		
+	
+	/**
+	 * Numbers of Logical step that have been called (may or may not have finished yet)
+	 * @return number of steps that have been called
+	 */
+	public long getNbLogicalStepCalled() {
+		return nbLogicalStepCalled;
+	}
+	/**
+	 * This method may be used to monitor engine progression 
+	 * @param nbLogicalStepCalled new value for nbLogicalStepCalled
+	 */
+	public void setNbLogicalStepCalled(long nbLogicalStepCalled) {
+		this.nbLogicalStepCalled = nbLogicalStepCalled;
+	}
+	
+	/**
+	 * An engine is responsible for incrementing this when a LogicalStep will be called
+	 */
+	public void incrementNbLogicalStepCalled() {
+		this.nbLogicalStepCalled +=1;
+	}
 	
 }


### PR DESCRIPTION
This PR adds a new data in `org.eclipse.gemoc.xdsmlframework.api.core.engineStatus`
In addition of  nbLogicalStepRun that returns the number of completed steps there is now also the number of called step. 

This information is used to display a better Engine View by also showing the "Not Completed" steps

It is also used in by test suites in order to manage the execution (and reduce flaky tests https://github.com/eclipse/gemoc-studio/issues/123 )


In the following capture, the number between square brackets indicates the number of not completed steps (which in this case is the same as the depth of the stack)
![image](https://user-images.githubusercontent.com/661468/72160243-46a14b80-33be-11ea-84e1-754df3bdd7c5.png)
