### PR TITLE
Move some reusable Context and Runconfiguration classes from JavaEngine to execution framework

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.executionframework.engine,
  org.eclipse.gemoc.executionframework.engine.commons,
  org.eclipse.gemoc.executionframework.engine.commons.adapters,
+ org.eclipse.gemoc.executionframework.engine.commons.sequential,
  org.eclipse.gemoc.executionframework.engine.core,
  org.eclipse.gemoc.executionframework.engine.profiler
 Automatic-Module-Name: org.eclipse.gemoc.executionframework.engine

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/GenericModelExecutionContext.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/GenericModelExecutionContext.java
@@ -8,21 +8,18 @@
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
-package org.eclipse.gemoc.execution.sequential.javaengine;
+package org.eclipse.gemoc.executionframework.engine.commons;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.gemoc.executionframework.engine.commons.AbstractModelExecutionContext;
-import org.eclipse.gemoc.executionframework.engine.commons.DefaultExecutionPlatform;
-import org.eclipse.gemoc.executionframework.engine.commons.EngineContextException;
 import org.eclipse.gemoc.trace.commons.model.trace.MSEModel;
 import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtension;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtensionPoint;
 
-public class SequentialModelExecutionContext<T extends IRunConfiguration> extends AbstractModelExecutionContext<T, DefaultExecutionPlatform, LanguageDefinitionExtension> {
+public class GenericModelExecutionContext<T extends IRunConfiguration> extends AbstractModelExecutionContext<T, DefaultExecutionPlatform, LanguageDefinitionExtension> {
 
-	public SequentialModelExecutionContext(T runConfiguration, ExecutionMode executionMode)
+	public GenericModelExecutionContext(T runConfiguration, ExecutionMode executionMode)
 			throws EngineContextException {
 		super(runConfiguration, executionMode);
 	}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/GenericModelExecutionContext.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/GenericModelExecutionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Inria and others.
+ * Copyright (c) 2016, 2020 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ public class GenericModelExecutionContext<T extends IRunConfiguration> extends A
 				.findDefinition(_runConfiguration.getLanguageName());
 		if (languageDefinition == null) {
 			String message = "Cannot find xdsml definition for the language "
-					+ _runConfiguration.getLanguageName() + ", please verify that is is correctly deployed.";
+					+ _runConfiguration.getLanguageName() + ", please verify that it is correctly deployed.";
 			EngineContextException exception = new EngineContextException(message);
 			throw exception;
 		}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/ISequentialRunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/ISequentialRunConfiguration.java
@@ -1,8 +1,11 @@
-package org.eclipse.gemoc.execution.sequential.javaengine;
+package org.eclipse.gemoc.executionframework.engine.commons.sequential;
 
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 
-public interface IK3RunConfiguration extends IRunConfiguration {
+/**
+ * Basic IRunConfiguration that can be used by sequential engines
+ */
+public interface ISequentialRunConfiguration extends IRunConfiguration {
 
 	public static final String LAUNCH_MODEL_ENTRY_POINT = "LAUNCH_MODEL_ENTRY_POINT";
 	public static final String LAUNCH_METHOD_ENTRY_POINT = "LAUNCH_METHOD_ENTRY_POINT";

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/SequentialRunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/SequentialRunConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Inria and others.
+ * Copyright (c) 2016, 2020 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,15 +8,18 @@
  * Contributors:
  *     Inria - initial API and implementation
  *******************************************************************************/
-package org.eclipse.gemoc.execution.sequential.javaengine;
+package org.eclipse.gemoc.executionframework.engine.commons.sequential;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.gemoc.executionframework.engine.core.RunConfiguration;
 
-public class K3RunConfiguration extends RunConfiguration implements IK3RunConfiguration {
+/**
+ * Basic RunConfiguration that can be used by sequential engines
+ */
+public class SequentialRunConfiguration extends RunConfiguration implements ISequentialRunConfiguration {
 
-	public K3RunConfiguration(ILaunchConfiguration launchConfiguration) throws CoreException {
+	public SequentialRunConfiguration(ILaunchConfiguration launchConfiguration) throws CoreException {
 		super(launchConfiguration);
 	}
 

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Inria and others.
+ * Copyright (c) 2016, 2020 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,26 +16,26 @@ import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystem;
 import org.eclipse.gemoc.commons.eclipse.ui.ViewHelper;
-import org.eclipse.gemoc.execution.sequential.javaengine.IK3RunConfiguration;
-import org.eclipse.gemoc.execution.sequential.javaengine.K3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
-import org.eclipse.gemoc.execution.sequential.javaengine.SequentialModelExecutionContext;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator;
 import org.eclipse.gemoc.executionframework.engine.commons.EngineContextException;
+import org.eclipse.gemoc.executionframework.engine.commons.GenericModelExecutionContext;
+import org.eclipse.gemoc.executionframework.engine.commons.sequential.ISequentialRunConfiguration;
+import org.eclipse.gemoc.executionframework.engine.commons.sequential.SequentialRunConfiguration;
 import org.eclipse.gemoc.executionframework.engine.ui.launcher.AbstractSequentialGemocLauncher;
 import org.eclipse.gemoc.executionframework.ui.views.engine.EnginesStatusView;
 import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode;
 
-public class Launcher extends AbstractSequentialGemocLauncher<SequentialModelExecutionContext<IK3RunConfiguration>, IK3RunConfiguration> {
+public class Launcher extends AbstractSequentialGemocLauncher<GenericModelExecutionContext<ISequentialRunConfiguration>, ISequentialRunConfiguration> {
 
 	public final static String TYPE_ID = Activator.PLUGIN_ID + ".launcher";
 
 	@Override
-	protected PlainK3ExecutionEngine createExecutionEngine(IK3RunConfiguration runConfiguration,
+	protected PlainK3ExecutionEngine createExecutionEngine(ISequentialRunConfiguration runConfiguration,
 			ExecutionMode executionMode) throws CoreException, EngineContextException {
 		// create and initialize engine
 		PlainK3ExecutionEngine executionEngine = new PlainK3ExecutionEngine();
-		SequentialModelExecutionContext<IK3RunConfiguration> executioncontext = new SequentialModelExecutionContext<IK3RunConfiguration>(
+		GenericModelExecutionContext<ISequentialRunConfiguration> executioncontext = new GenericModelExecutionContext<ISequentialRunConfiguration>(
 				runConfiguration, executionMode);
 		executioncontext.getExecutionPlatform().getModelLoader().setProgressMonitor(this.launchProgressMonitor);
 		executioncontext.initializeResourceModel();
@@ -69,8 +69,8 @@ public class Launcher extends AbstractSequentialGemocLauncher<SequentialModelExe
 	}
 
 	@Override
-	protected K3RunConfiguration parseLaunchConfiguration(ILaunchConfiguration configuration) throws CoreException {
-		return new K3RunConfiguration(configuration);
+	protected SequentialRunConfiguration parseLaunchConfiguration(ILaunchConfiguration configuration) throws CoreException {
+		return new SequentialRunConfiguration(configuration);
 	}
 
 	@Override

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/src/org/eclipse/gemoc/execution/sequential/javaengine/ui/launcher/tabs/LaunchConfigurationMainTab.java
@@ -29,13 +29,13 @@ import org.eclipse.gemoc.commons.eclipse.emf.URIHelper;
 import org.eclipse.gemoc.commons.eclipse.ui.dialogs.SelectAnyIFileDialog;
 import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
 import org.eclipse.gemoc.dsl.debug.ide.sirius.ui.launch.AbstractDSLLaunchConfigurationDelegateSiriusUI;
-import org.eclipse.gemoc.execution.sequential.javaengine.K3RunConfiguration;
 import org.eclipse.gemoc.execution.sequential.javaengine.PlainK3ExecutionEngine;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.Activator;
 import org.eclipse.gemoc.execution.sequential.javaengine.ui.launcher.LauncherMessages;
 import org.eclipse.gemoc.executionframework.engine.commons.DslHelper;
 import org.eclipse.gemoc.executionframework.engine.commons.K3DslHelper;
 import org.eclipse.gemoc.executionframework.engine.commons.MelangeHelper;
+import org.eclipse.gemoc.executionframework.engine.commons.sequential.SequentialRunConfiguration;
 import org.eclipse.gemoc.executionframework.engine.ui.launcher.tabs.AbstractLaunchConfigurationTab;
 import org.eclipse.gemoc.executionframework.ui.utils.ENamedElementQualifiedNameLabelProvider;
 import org.eclipse.gemoc.xdsmlframework.ui.utils.dialogs.SelectAIRDIFileDialog;
@@ -123,16 +123,16 @@ public class LaunchConfigurationMainTab extends AbstractLaunchConfigurationTab {
 
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_DELAY, 1000);
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_MODEL_ENTRY_POINT, "");
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_METHOD_ENTRY_POINT, "");
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_SELECTED_LANGUAGE, "");
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_DELAY, 1000);
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_MODEL_ENTRY_POINT, "");
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_METHOD_ENTRY_POINT, "");
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_SELECTED_LANGUAGE, "");
 	}
 
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		try {
-			K3RunConfiguration runConfiguration = new K3RunConfiguration(
+			SequentialRunConfiguration runConfiguration = new SequentialRunConfiguration(
 					configuration);
 			_modelLocationText.setText(URIHelper
 					.removePlatformScheme(runConfiguration
@@ -173,24 +173,24 @@ public class LaunchConfigurationMainTab extends AbstractLaunchConfigurationTab {
 		configuration.setAttribute(
 				AbstractDSLLaunchConfigurationDelegateSiriusUI.SIRIUS_RESOURCE_URI,
 				this._siriusRepresentationLocationText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_DELAY,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_DELAY,
 				Integer.parseInt(_delayText.getText()));
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_SELECTED_LANGUAGE,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_SELECTED_LANGUAGE,
 				_languageCombo.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_MELANGE_QUERY,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_MELANGE_QUERY,
 				_melangeQueryText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_MODEL_ENTRY_POINT,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_MODEL_ENTRY_POINT,
 				_entryPointModelElementText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_METHOD_ENTRY_POINT,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_METHOD_ENTRY_POINT,
 				_entryPointMethodText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_INITIALIZATION_METHOD,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_INITIALIZATION_METHOD,
 				_modelInitializationMethodText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_INITIALIZATION_ARGUMENTS,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_INITIALIZATION_ARGUMENTS,
 				_modelInitializationArgumentsText.getText());
-		configuration.setAttribute(K3RunConfiguration.LAUNCH_BREAK_START,
+		configuration.setAttribute(SequentialRunConfiguration.LAUNCH_BREAK_START,
 				_animationFirstBreak.getSelection());
 		// DebugModelID for sequential engine
-		configuration.setAttribute(K3RunConfiguration.DEBUG_MODEL_ID, Activator.DEBUG_MODEL_ID);
+		configuration.setAttribute(SequentialRunConfiguration.DEBUG_MODEL_ID, Activator.DEBUG_MODEL_ID);
 	}
 
 	@Override

--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Inria and others.
+ * Copyright (c) 2016, 2020 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,9 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.impl.InternalTransactionalEditingDomain;
+import org.eclipse.gemoc.executionframework.engine.commons.GenericModelExecutionContext;
 import org.eclipse.gemoc.executionframework.engine.commons.K3DslHelper;
+import org.eclipse.gemoc.executionframework.engine.commons.sequential.ISequentialRunConfiguration;
 import org.eclipse.gemoc.executionframework.engine.core.AbstractCommandBasedSequentialExecutionEngine;
 import org.eclipse.gemoc.executionframework.engine.core.EngineStoppedException;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -52,7 +54,7 @@ import fr.inria.diverse.melange.adapters.EObjectAdapter;
  * @author Didier Vojtisek<didier.vojtisek@inria.fr>
  *
  */
-public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine<SequentialModelExecutionContext<IK3RunConfiguration>, IK3RunConfiguration>
+public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecutionEngine<GenericModelExecutionContext<ISequentialRunConfiguration>, ISequentialRunConfiguration>
 		implements IStepManager {
 
 	private Method initializeMethod;
@@ -74,7 +76,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * operation.
 	 */
 	@Override
-	protected void prepareEntryPoint(SequentialModelExecutionContext<IK3RunConfiguration> executionContext) {
+	protected void prepareEntryPoint(GenericModelExecutionContext<ISequentialRunConfiguration> executionContext) {
 		/*
 		 * Get info from the RunConfiguration
 		 */
@@ -128,7 +130,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	}
 
 	@Override
-	protected void prepareInitializeModel(SequentialModelExecutionContext<IK3RunConfiguration> executionContext) {
+	protected void prepareInitializeModel(GenericModelExecutionContext<ISequentialRunConfiguration> executionContext) {
 
 		// try to get the initializeModelRunnable
 		String modelInitializationMethodQName = executionContext.getRunConfiguration().getModelInitializationMethod();
@@ -318,7 +320,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * 
 	 * Return null if not found.
 	 */
-	private Bundle findBundle(final SequentialModelExecutionContext<IK3RunConfiguration> executionContext, String aspectClassName) {
+	private Bundle findBundle(final GenericModelExecutionContext<ISequentialRunConfiguration> executionContext, String aspectClassName) {
 
 		// Look using JavaWorkspaceScope as this is safer and will look in
 		// dependencies


### PR DESCRIPTION
In order to remove dependencies from ALE to JavaEngine (cf. https://github.com/eclipse/gemoc-studio-execution-ale/issues/29), this PR moves (and rename) some IRunConfiguration and ModelExecutionContext classes from JavaEngine to org.eclipse.gemoc.executionframework.engine

Moved and renamed classes:
-  `org.eclipse.gemoc.execution.sequential.javaengine.SequentialModelExecutionContext `-> `org.eclipse.gemoc.executionframework.engine.commons.GenericModelExecutionContext`
-  `org.eclipse.gemoc.execution.sequential.javaengine.IK3RunConfiguration` -> `org.eclipse.gemoc.executionframework.engine.commons.ISequentialRunConfiguration`
-  `org.eclipse.gemoc.execution.sequential.javaengine.sequential.IK3RunConfiguration` -> `org.eclipse.gemoc.executionframework.engine.commons.sequential.SequentialRunConfiguration`