### PR TITLE
Remove Logical Step View from perspective extension declaration

### DIFF
--- a/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/plugin.xml
+++ b/java_execution/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine.ui/plugin.xml
@@ -184,31 +184,7 @@
          <actionSet
                id="org.eclipse.debug.ui.launchActionSet">
          </actionSet>
-      </perspectiveExtension>
-      <perspectiveExtension
-            targetID="org.eclipse.sirius.ui.tools.perspective.modeling">
-        <!-- <newWizardShortcut
-               id="org.eclipse.gemoc.gemoc_modeling_workbench.ui.wizards.CreateNewGemocModelingProject">
-         </newWizardShortcut>-->
-         <view
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
-               minimized="false"
-               relationship="stack"
-               relative="org.eclipse.sirius.ui.tools.views.model.explorer"
-               visible="true">
-         </view>
-      </perspectiveExtension>
-      <perspectiveExtension
-            targetID="org.eclipse.debug.ui.DebugPerspective">
-         <view
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
-               minimized="false"
-               ratio="0.5"
-               relationship="right"
-               relative="org.eclipse.debug.ui.VariableView">
-         </view>
-      </perspectiveExtension>
-      
+      </perspectiveExtension>      
    </extension>
    
       <extension


### PR DESCRIPTION
The perspective extension should not configure the position of the Logical Step view
in Java Engine as it is already declared in Moccml Engine (where this view
is defined)

This double declaration (in java engine and moccml engine) was inconsistent and was creating an empty area in the workbench
