### PR TITLE
Documentation for Addon priority

### DIFF
--- a/framework/execution_framework/docs/dev/images/dev/ExecutionEngine_Typical_flow_SD.plantuml
+++ b/framework/execution_framework/docs/dev/images/dev/ExecutionEngine_Typical_flow_SD.plantuml
@@ -35,6 +35,11 @@ deactivate Launcher
 deactivate Launcher
 
 Engine --> addon : engineAboutToStart
+note right
+	if required, the order of the calls to the Addons 
+	can be controled by defining 
+	EngineAddonSortingRules in the Addons
+end note
 Engine -> Engine : beforeStart
 Engine --> addon : engineStarted
 Engine -> Engine : performStart

--- a/framework/framework_commons/docs/dev/FrameworkCommons.asciidoc
+++ b/framework/framework_commons/docs/dev/FrameworkCommons.asciidoc
@@ -24,3 +24,5 @@ Most notably, the _IEngineAddon_ and _IExecutionEngine_ interfaces that are the 
 image::images/dev/frameworkcommons_api_overview_CD.png["Execution Framework API Interfaces overview"]
 
 
+TIP: The section <<dev-new-addons>> contains some details and code snippets about how to write an engine addon.
+

--- a/framework/framework_commons/docs/dev/images/dev/frameworkcommons_api_overview_CD.plantuml
+++ b/framework/framework_commons/docs/dev/images/dev/frameworkcommons_api_overview_CD.plantuml
@@ -9,6 +9,7 @@ scale max 1024 width
 scale max 800 height
 
 package xdsmlframework.api.engine_addon {
+	
 	interface IEngineAddon #beige {
 		void engineAboutToStart(IExecutionEngine engine)
 		void engineStarted(IExecutionEngine executionEngine)
@@ -23,7 +24,40 @@ package xdsmlframework.api.engine_addon {
 		void stepExecuted(IExecutionEngine engine, trace.commons.model.trace.Step<?> stepExecuted)
 		void engineStatusChanged(IExecutionEngine engine, EngineStatus.RunStatus newStatus)
 		List<String> validate(List<engine_addon.IEngineAddon> otherAddons)
+		String getAddonID()
+		List<String> getTags()
+		List<EngineAddonSortingRule> getAddonSortingRules()
 	}
+	
+	class EngineAddonSortingRule {
+		Priority priority
+		IEngineAddon owner;
+		EngineEvent event;
+		Priority priority;
+		List<String> addonsWithTags;
+	}
+	enum Priority {
+		BEFORE
+		AFTER
+	}
+	enum EngineEvent {
+		engineAboutToStart
+		engineStarted,
+		engineInitialized
+		engineAboutToStop,
+		engineStopped
+		engineAboutToDispose
+		aboutToSelectStep
+		proposedStepsChanged
+		stepSelected
+		aboutToExecuteStep
+		stepExecuted
+		engineStatusChanged
+	}
+	
+	Priority -[hidden]> EngineAddonSortingRule
+	EngineEvent -[hidden]> EngineAddonSortingRule
+	IEngineAddon <-- EngineAddonSortingRule : owner
 }
 
 package xdsmlframework.api.core {

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/IEngineAddon.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/engine_addon/IEngineAddon.java
@@ -113,7 +113,7 @@ public interface IEngineAddon {
 	 * A given rule indicate when to call the current addon relatively to addons referred by the rule
 	 * @return
 	 */
-	default public List<EngineAddonSortingRule> getAddonSortingRules(){
+	default public List<EngineAddonSortingRule> getAddonSortingRules() {
 		return new ArrayList<EngineAddonSortingRule>();
 	}
 	


### PR DESCRIPTION
Updated documentation about IEngineAddon interface and priority management between addons

contributes to https://github.com/eclipse/gemoc-studio-modeldebugging/issues/151