### PR TITLE
Adds Addon parameter feature and makes equivalency classes computing optional

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/AbstractLaunchConfigurationDataProcessingTab.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/AbstractLaunchConfigurationDataProcessingTab.java
@@ -36,8 +36,6 @@ import org.eclipse.swt.widgets.Group;
 
 public abstract class AbstractLaunchConfigurationDataProcessingTab extends AbstractLaunchConfigurationTab
 		implements ILaunchLanguageSelectionListener {
-	
-	public static String OPTION_CONF_ID_SEPARATOR = "_option_";
 
 	private HashMap<EngineAddonSpecificationExtension, EngineAddonLaunchConfigWidget> _components = new HashMap<>();
 	

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/EngineAddonLaunchConfigWidget.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/EngineAddonLaunchConfigWidget.java
@@ -139,7 +139,7 @@ public class EngineAddonLaunchConfigWidget {
 		if( optionGroup != null) {
 			for(EngineAddonBooleanOptionSpecificationExtension booleanOption : booleanOptionButtons.keySet()) {
 				try {
-					String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + booleanOption.getId();
+					String key = booleanOption.getId();
 					boolean value = configuration.getAttribute(key, false);
 					booleanOptionButtons.get(booleanOption).setSelection(value);
 				} catch (CoreException e) {
@@ -149,7 +149,7 @@ public class EngineAddonLaunchConfigWidget {
 
 			for(EngineAddonStringOptionSpecificationExtension option : stringOptionTexts.keySet()) {
 				try {
-					String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + option.getId();
+					String key = option.getId();
 					String value = configuration.getAttribute(key, "");
 					stringOptionTexts.get(option).setText(value);
 				} catch (CoreException e) {
@@ -161,12 +161,12 @@ public class EngineAddonLaunchConfigWidget {
 	public void optionsPerformApply(ILaunchConfigurationWorkingCopy configuration){
 		if( optionGroup != null) {
 			for(EngineAddonBooleanOptionSpecificationExtension booleanOption : booleanOptionButtons.keySet()) {
-				String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + booleanOption.getId();
+				String key = booleanOption.getId();
 				configuration.setAttribute(key, booleanOptionButtons.get(booleanOption).getSelection());
 			}
 
 			for(EngineAddonStringOptionSpecificationExtension option : stringOptionTexts.keySet()) {
-				String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + option.getId();
+				String key = option.getId();
 				configuration.setAttribute(key, stringOptionTexts.get(option).getText());
 			}
 		}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/EngineAddonLaunchConfigWidget.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/EngineAddonLaunchConfigWidget.java
@@ -1,0 +1,175 @@
+package org.eclipse.gemoc.executionframework.engine.ui.launcher.tabs;
+
+import java.util.HashMap;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.gemoc.executionframework.engine.ui.Activator;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonBooleanOptionSpecificationExtension;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonStringOptionSpecificationExtension;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+
+public class EngineAddonLaunchConfigWidget {
+
+	
+	
+	Button mainCheckButton;
+	Group optionGroup = null;
+	private HashMap<EngineAddonBooleanOptionSpecificationExtension, Button> booleanOptionButtons = new HashMap<>();
+	private HashMap<EngineAddonStringOptionSpecificationExtension, Text> stringOptionTexts = new HashMap<>();
+	AbstractLaunchConfigurationDataProcessingTab parentTab;
+	EngineAddonSpecificationExtension extension;
+	
+	
+	
+	public EngineAddonLaunchConfigWidget(AbstractLaunchConfigurationDataProcessingTab parentTab, Composite parent, EngineAddonSpecificationExtension extension) {
+		this.parentTab = parentTab;
+		this.extension = extension;
+		createComponentForExtension(parent, extension);
+	}
+
+	protected void createComponentForExtension(Composite parentGroup, EngineAddonSpecificationExtension extension) {
+		if(! extension.getAddonBooleanOptionsIds().isEmpty() || ! extension.getAddonStringOptionsIds().isEmpty()) {
+			// TODO need to create options for this addon
+		}
+		
+		mainCheckButton = LaunchConfUtils.createCheckButton(parentGroup, extension.getName() + ":");
+		mainCheckButton.setToolTipText(extension.getId() + " contributed by " + extension.getContributorName());
+		// checkbox.setSelection(extension.getDefaultActivationValue());
+		mainCheckButton.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				setOptionsEnabled(mainCheckButton.getSelection());
+				parentTab.updateTab();
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
+		String desc;
+		if (extension.getShortDescription() != null) {
+			desc = extension.getShortDescription();
+		} else
+			desc = "";
+		LaunchConfUtils.createTextLabelLayout(parentGroup, desc, "contributed by " + extension.getContributorName());
+		
+		
+		// create option group if required
+		if(!extension.getAddonBooleanOptionsIds().isEmpty() || !extension.getAddonStringOptionsIds().isEmpty()) {
+			optionGroup = LaunchConfUtils.createGroup(parentGroup, "addon options", 2);
+			GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false); //new GridData(GridData.VERTICAL_ALIGN_END);
+		    gridData.horizontalSpan = 2;
+		    gridData.horizontalIndent = 30;
+		    gridData.horizontalAlignment = GridData.FILL;
+		    
+		    optionGroup.setLayoutData(gridData);
+		    
+		    for(EngineAddonBooleanOptionSpecificationExtension booleanOption : extension.getAddonBooleanOptionSpecificationExtensions()) {
+		    	Label l = LaunchConfUtils.createTextLabelLayout(optionGroup, booleanOption.getName()+":");
+		    	GridData gd = new GridData(SWT.RIGHT, SWT.TOP, false, false); // do not grab excess space
+				l.setLayoutData(gd);
+		    	Button b = LaunchConfUtils.createCheckButton(optionGroup, ""); // button on right so no label
+				b.addSelectionListener(new SelectionListener() {
+
+					@Override
+					public void widgetSelected(SelectionEvent e) {
+						parentTab.updateTab();
+					}
+
+					@Override
+					public void widgetDefaultSelected(SelectionEvent e) {
+					}
+				});
+				if (extension.getShortDescription() != null) {
+					b.setToolTipText(booleanOption.getShortDescription());
+					l.setToolTipText(booleanOption.getShortDescription());
+				}
+				this.booleanOptionButtons.put(booleanOption, b);
+		    }
+		    for(EngineAddonStringOptionSpecificationExtension stringOption : extension.getAddonStringOptionSpecificationExtensions()) {
+		    	
+		    	Label l = LaunchConfUtils.createTextLabelLayout(optionGroup, stringOption.getName()+":");
+		    	GridData gd = new GridData(SWT.RIGHT, SWT.TOP, false, false); // do not grab excess space
+				l.setLayoutData(gd);
+				// Model location text
+		    	Text t = new Text(optionGroup, SWT.SINGLE | SWT.BORDER);
+				t.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+				t.setFont(null);
+				t.addModifyListener(new ModifyListener() {
+					@Override
+					public void modifyText(ModifyEvent arg0) {
+						parentTab.updateTab();
+					}
+				});
+				if (extension.getShortDescription() != null) {
+					t.setToolTipText(stringOption.getShortDescription());
+				}
+				this.stringOptionTexts.put(stringOption, t);
+		    }
+		}
+	}
+
+	
+	public void setOptionsEnabled(boolean enabled) {
+		if( optionGroup != null) {
+			optionGroup.setEnabled(enabled);
+			for(Control c: optionGroup.getChildren()) {
+				c.setEnabled(enabled);
+			}
+		}
+	}
+	
+	
+	public void optionInitializeFrom(ILaunchConfiguration configuration) {
+		if( optionGroup != null) {
+			for(EngineAddonBooleanOptionSpecificationExtension booleanOption : booleanOptionButtons.keySet()) {
+				try {
+					String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + booleanOption.getId();
+					boolean value = configuration.getAttribute(key, false);
+					booleanOptionButtons.get(booleanOption).setSelection(value);
+				} catch (CoreException e) {
+					Activator.error(e.getMessage(), e);
+				}
+			}
+
+			for(EngineAddonStringOptionSpecificationExtension option : stringOptionTexts.keySet()) {
+				try {
+					String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + option.getId();
+					String value = configuration.getAttribute(key, "");
+					stringOptionTexts.get(option).setText(value);
+				} catch (CoreException e) {
+					Activator.error(e.getMessage(), e);
+				}
+			}
+		}
+	}
+	public void optionsPerformApply(ILaunchConfigurationWorkingCopy configuration){
+		if( optionGroup != null) {
+			for(EngineAddonBooleanOptionSpecificationExtension booleanOption : booleanOptionButtons.keySet()) {
+				String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + booleanOption.getId();
+				configuration.setAttribute(key, booleanOptionButtons.get(booleanOption).getSelection());
+			}
+
+			for(EngineAddonStringOptionSpecificationExtension option : stringOptionTexts.keySet()) {
+				String key = extension.getId() + AbstractLaunchConfigurationDataProcessingTab.OPTION_CONF_ID_SEPARATOR + option.getId();
+				configuration.setAttribute(key, stringOptionTexts.get(option).getText());
+			}
+		}
+	}
+	
+}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/LaunchConfUtils.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/launcher/tabs/LaunchConfUtils.java
@@ -1,0 +1,81 @@
+package org.eclipse.gemoc.executionframework.engine.ui.launcher.tabs;
+
+import org.eclipse.debug.internal.ui.SWTFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+
+public class LaunchConfUtils {
+
+	/**
+	 * Create a group with the default number of columns (3)
+	 * 
+	 * @param parent
+	 * @param text
+	 * @return
+	 */
+	public static Group createGroup(Composite parent, String text) {
+		return createGroup(parent, text, 3);
+	}
+
+	/**
+	 * create a group with the specified number of columns
+	 * 
+	 * @param parent
+	 * @param text
+	 * @param nbColumn
+	 * @return
+	 */
+	public static  Group createGroup(Composite parent, String text, int nbColumn) {
+		Group group = new Group(parent, SWT.NULL);
+		group.setText(text);
+		GridLayout locationLayout = new GridLayout(nbColumn, false);
+		locationLayout.numColumns = nbColumn;
+		locationLayout.marginHeight = 10;
+		locationLayout.marginWidth = 10;
+		group.setLayout(locationLayout);
+		GridData gd = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		group.setLayoutData(gd);
+		return group;
+	}
+
+	/**
+	 * 
+	 * @param parent      the Parent of this argument tab
+	 * @param labelString the label of the input text to create
+	 */
+	public static  Label createTextLabelLayout(Composite parent, String labelString) {
+		Label inputLabel = new Label(parent, SWT.NONE);
+		inputLabel.setText(labelString); // $NON-NLS-1$
+		GridData gd = new GridData(SWT.LEFT, SWT.CENTER, true, false);
+		// gd.horizontalSpan = 2;
+		inputLabel.setLayoutData(gd);
+		return inputLabel;
+	}
+
+	/**
+	 * 
+	 * @param parent      the Parent of this argument tab
+	 * @param labelString the label of the input text to create
+	 * @param toolTipText the text for tool tip
+	 */
+	public static Label createTextLabelLayout(Composite parent, String labelString, String toolTipText) {
+		//GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		//parent.setLayoutData(gd);
+		Label inputLabel = new Label(parent, SWT.NONE);
+		inputLabel.setText(labelString); // $NON-NLS-1$
+		inputLabel.setToolTipText(toolTipText);
+		GridData gd = new GridData(SWT.LEFT, SWT.CENTER, true, false);
+		// gd.horizontalSpan = 2;
+		inputLabel.setLayoutData(gd);
+		return inputLabel;
+	}	
+	
+	public static Button createCheckButton(Composite parent, String label) {
+		return SWTFactory.createCheckButton(parent, label, null, false, 1);
+	}
+}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.gemoc.dsl.debug.ide.launch.AbstractDSLLaunchConfigurationDelegate;
+import org.eclipse.gemoc.executionframework.engine.Activator;
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtensionPoint;
@@ -64,16 +65,31 @@ public class RunConfiguration implements IRunConfiguration {
 		_debugModelID = getAttribute(DEBUG_MODEL_ID, ".debugModel");
 	}
 
-	protected String getAttribute(String attributeName, String defaultValue) throws CoreException {
-		return _launchConfiguration.getAttribute(attributeName, defaultValue);
+	public String getAttribute(String attributeName, String defaultValue) {
+		try {
+			return _launchConfiguration.getAttribute(attributeName, defaultValue);
+		} catch (CoreException e) {
+			Activator.getDefault().error(e.getMessage(), e);
+			return defaultValue;
+		}
 	}
 
-	protected Integer getAttribute(String attributeName, Integer defaultValue) throws CoreException {
-		return _launchConfiguration.getAttribute(attributeName, defaultValue);
+	public Integer getAttribute(String attributeName, Integer defaultValue) {
+		try {
+			return _launchConfiguration.getAttribute(attributeName, defaultValue);
+		} catch (CoreException e) {
+			Activator.getDefault().error(e.getMessage(), e);
+			return defaultValue;
+		}
 	}
 
-	protected Boolean getAttribute(String attributeName, Boolean defaultValue) throws CoreException {
-		return _launchConfiguration.getAttribute(attributeName, defaultValue);
+	public Boolean getAttribute(String attributeName, Boolean defaultValue) {
+		try {
+			return _launchConfiguration.getAttribute(attributeName, defaultValue);
+		} catch (CoreException e) {
+			Activator.getDefault().error(e.getMessage(), e);
+			return defaultValue;
+		}
 	}
 
 	private int _animationDelay = 0;

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.engine_addon.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.engine_addon.exsd
@@ -130,7 +130,8 @@ The hooked code will be run at the appropriate time by the engine.
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  ID of the option
+                  UID of the option. 
+(please use a long qualified name including the addon id in order to avoid conflicts with similar option in other addons)
                </documentation>
             </annotation>
          </attribute>
@@ -168,7 +169,8 @@ The hooked code will be run at the appropriate time by the engine.
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  ID of the option
+                  UID of the option. 
+(please use a long qualified name including the addon id in order to avoid conflicts with similar option in other addons)
                </documentation>
             </annotation>
          </attribute>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.engine_addon.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.engine_addon.exsd
@@ -54,6 +54,12 @@
          </documentation>
       </annotation>
       <complexType>
+         <sequence minOccurs="0" maxOccurs="unbounded">
+            <choice>
+               <element ref="addon_booleanOption"/>
+               <element ref="addon_stringOption"/>
+            </choice>
+         </sequence>
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
@@ -108,6 +114,82 @@ The hooked code will be run at the appropriate time by the engine.
             <annotation>
                <documentation>
                   comma separated list of view ids that should be opened when the addon is used in Eclipse UI.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="addon_booleanOption">
+      <annotation>
+         <documentation>
+            add a boolean option to engine addon
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the option
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of the option as it will be displayed to the end user when he will select it in the Launcher GUI
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="shortDescription" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="defaultValue" type="boolean">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="addon_stringOption">
+      <annotation>
+         <documentation>
+            add a string option to engine addon
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the option
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of the option as it will be displayed to the end user when he will select it in the Launcher GUI
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="shortDescription" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="defaultValue" type="string">
+            <annotation>
+               <documentation>
+                  
                </documentation>
             </annotation>
          </attribute>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
@@ -84,7 +84,7 @@
 
    <element name="engineAddon_Definition">
       <complexType>
-         <sequence minOccurs="1" maxOccurs="unbounded">
+         <sequence minOccurs="0" maxOccurs="unbounded">
             <choice>
                <element ref="addon_booleanOption"/>
                <element ref="addon_stringOption"/>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
@@ -176,7 +176,8 @@ If not set, language specific addons are enabled by default.
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  ID of the option
+                  UID of the option. 
+(please use a long qualified name including the addon id in order to avoid conflicts with similar option in other addons)
                </documentation>
             </annotation>
          </attribute>
@@ -214,7 +215,8 @@ If not set, language specific addons are enabled by default.
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  ID of the option
+                  UID of the option. 
+(please use a long qualified name including the addon id in order to avoid conflicts with similar option in other addons)
                </documentation>
             </annotation>
          </attribute>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.xdsml.exsd
@@ -3,7 +3,7 @@
 <schema targetNamespace="org.eclipse.gemoc.gemoc_language_workbench.ui" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="org.eclipse.gemoc.gemoc_language_workbench.ui" id="org.eclipse.gemoc.gemoc_language_workbench.xdsml" name="Gemoc Language Definition"/>
+         <meta.schema plugin="org.eclipse.gemoc.gemoc_language_workbench.ui" id="org.eclipse.gemoc.gemoc_language_workbench.xdsml" name="GEMOC Language Definition"/>
       </appinfo>
       <documentation>
          [Enter description of this extension point.]
@@ -84,6 +84,12 @@
 
    <element name="engineAddon_Definition">
       <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <choice>
+               <element ref="addon_booleanOption"/>
+               <element ref="addon_stringOption"/>
+            </choice>
+         </sequence>
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
@@ -151,6 +157,82 @@ If not set, language specific addons are enabled by default.
    <element name="XDSML_Definition_Customization">
       <complexType>
          <attribute name="fileExtensions" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="addon_booleanOption">
+      <annotation>
+         <documentation>
+            allows to add a boolean option to engine addon
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the option
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of the option as it will be displayed to the end user when he will select it in the Launcher GUI
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="shortDescription" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="defaultValue" type="boolean">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="addon_stringOption">
+      <annotation>
+         <documentation>
+            add a string option to engine addon
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the option
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of the option as it will be displayed to the end user when he will select it in the Launcher GUI
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="shortDescription" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="defaultValue" type="string">
             <annotation>
                <documentation>
                   

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
@@ -40,6 +40,35 @@ public interface IRunConfiguration {
 
 	int getAnimationDelay();
 	
+	/**
+	 * return a string attribute from the runconfiguration identified by attributeName
+	 * returns the default value if not found
+	 * This is useful for addon options for example
+	 * @param attributeName
+	 * @param defaultValue
+	 * @return
+	 */
+	String getAttribute(String attributeName, String defaultValue);
+
+	/**
+	 * return an integer attribute from the runconfiguration identified by attributeName
+	 * returns the default value if not found
+	 * This is useful for addon options for example
+	 * @param attributeName
+	 * @param defaultValue
+	 * @return
+	 */	
+	Integer getAttribute(String attributeName, Integer defaultValue);
+
+	/**
+	 * return a boolean attribute from the runconfiguration identified by attributeName
+	 * returns the default value if not found
+	 * This is useful for addon options for example
+	 * @param attributeName
+	 * @param defaultValue
+	 * @return
+	 */	
+	Boolean getAttribute(String attributeName, Boolean defaultValue);
 	
 	/**
 	 * the list of enabled engine addons

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/AbstractEngineAddonOptionSpecificationExtension.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/AbstractEngineAddonOptionSpecificationExtension.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.Extension;
+
+public class AbstractEngineAddonOptionSpecificationExtension extends Extension
+{
+
+	public AbstractEngineAddonOptionSpecificationExtension() {
+	}
+	public AbstractEngineAddonOptionSpecificationExtension(IConfigurationElement configurationElement) {
+		_configurationElement = configurationElement;
+	}
+	
+	public String getId()
+	{
+		return getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_ID);
+	}
+
+	public String getName()
+	{
+		return getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_NAME);
+	}
+	
+	public String getShortDescription()
+	{
+		return getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_SHORTDESCRIPTION);
+	}
+	
+		
+}

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonBooleanOptionSpecificationExtension.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonBooleanOptionSpecificationExtension.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+
+public class EngineAddonBooleanOptionSpecificationExtension extends AbstractEngineAddonOptionSpecificationExtension
+{
+
+	public EngineAddonBooleanOptionSpecificationExtension() {
+	}
+	public EngineAddonBooleanOptionSpecificationExtension(IConfigurationElement configurationElement) {
+		super(configurationElement);
+	}
+
+	public boolean getDefaultValue()
+	{
+		return getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_DEFAULTVALUE).equalsIgnoreCase("true");
+	}
+		
+}

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonSpecificationExtension.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonSpecificationExtension.java
@@ -11,12 +11,14 @@
 package org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.gemoc.xdsmlframework.api.engine_addon.IEngineAddon;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.Extension;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtensionPoint;
 
 public class EngineAddonSpecificationExtension extends Extension
 {
@@ -62,6 +64,65 @@ public class EngineAddonSpecificationExtension extends Extension
 		}
 		return idsList;
 	}
+	
+	/**
+	 * 
+	 * @return the list of boolean option ids for the given engine
+	 */
+	public List<String> getAddonBooleanOptionsIds() {
+		ArrayList<String> booleanOptionIDs = new ArrayList<String>();
+		for (IConfigurationElement childConfElement : _configurationElement
+				.getChildren(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_BOOLEANOPTION)) {
+			childConfElement.getName();
+			final String booleanOptionIDString = childConfElement
+					.getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_ID);
+			if (booleanOptionIDString != null) {
+				for( String fileExtension : booleanOptionIDString.split(",")){
+					booleanOptionIDs.add(fileExtension.trim());
+				}
+			}
+		}
+		return booleanOptionIDs;
+	}
+	/**
+	 * 
+	 * @return the list of boolean option ids for the given engine
+	 */
+	public List<String> getAddonStringOptionsIds() {
+		ArrayList<String> optionIDs = new ArrayList<String>();
+		for (IConfigurationElement childConfElement : _configurationElement
+				.getChildren(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_STRINGOPTION)) {
+			childConfElement.getName();
+			final String optionIDString = childConfElement
+					.getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_ID);
+			if (optionIDString != null) {
+				for( String fileExtension : optionIDString.split(",")){
+					optionIDs.add(fileExtension.trim());
+				}
+			}
+		}
+		return optionIDs;
+	}
+	
+	final public Collection<EngineAddonBooleanOptionSpecificationExtension> getAddonBooleanOptionSpecificationExtensions() {
+		ArrayList<EngineAddonBooleanOptionSpecificationExtension> addonOptions = new ArrayList<EngineAddonBooleanOptionSpecificationExtension>();
+		for (IConfigurationElement childConfElement : _configurationElement
+				.getChildren(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_BOOLEANOPTION)) {
+			EngineAddonBooleanOptionSpecificationExtension engineAddonSpecificationExtension = new EngineAddonBooleanOptionSpecificationExtension(childConfElement);
+			addonOptions.add(engineAddonSpecificationExtension);
+		}
+		return addonOptions;
+	}
+	final public Collection<EngineAddonStringOptionSpecificationExtension> getAddonStringOptionSpecificationExtensions() {
+		ArrayList<EngineAddonStringOptionSpecificationExtension> addonOptions = new ArrayList<EngineAddonStringOptionSpecificationExtension>();
+		for (IConfigurationElement childConfElement : _configurationElement
+				.getChildren(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_STRINGOPTION)) {
+			EngineAddonStringOptionSpecificationExtension engineAddonSpecificationExtension = new EngineAddonStringOptionSpecificationExtension(childConfElement);
+			addonOptions.add(engineAddonSpecificationExtension);
+		}
+		return addonOptions;
+	}
+
 	
 	public IEngineAddon instanciateComponent() throws CoreException
 	{

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonSpecificationExtensionPoint.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonSpecificationExtensionPoint.java
@@ -28,6 +28,13 @@ public class EngineAddonSpecificationExtensionPoint extends ExtensionPoint<Engin
 	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_ADDONGROUPID = "addonGroupId";
 	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPENVIEWIDS = "openViewIds";
 
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_BOOLEANOPTION = "addon_booleanOption";
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_STRINGOPTION = "addon_stringOption";
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_ID = "id";
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_NAME = "name";
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_SHORTDESCRIPTION = "shortDescription";
+	public static final String GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_DEFAULTVALUE = "defaultValue";
+
 	protected EngineAddonSpecificationExtensionPoint() 
 	{
 		super(EngineAddonSpecificationExtension.class);

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonStringOptionSpecificationExtension.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/engine_addon/EngineAddonStringOptionSpecificationExtension.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Inria and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Inria - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+
+public class EngineAddonStringOptionSpecificationExtension extends AbstractEngineAddonOptionSpecificationExtension
+{
+
+	public EngineAddonStringOptionSpecificationExtension() {
+	}
+	public EngineAddonStringOptionSpecificationExtension(IConfigurationElement configurationElement) {
+		super(configurationElement);
+	}
+
+	public String getDefaultValue()
+	{
+		return getAttribute(EngineAddonSpecificationExtensionPoint.GEMOC_ENGINE_ADDON_EXTENSION_POINT_OPTION_DEFAULTVALUE);
+	}
+		
+}

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
@@ -15,6 +15,25 @@
 -->
 <plugin>
   <extension point="org.eclipse.gemoc.gemoc_language_workbench.engine_addon">
-    <addon class="org.eclipse.gemoc.trace.gemoc.traceaddon.GenericTraceEngineAddon" default="false" id="org.eclipse.gemoc.trace.gemoc.traceaddon" name="Generic MultiDimensional Data Trace" shortDescription="Data Trace support for any language" openViewIds="org.eclipse.gemoc.addon.multidimensional.timeline.views.timeline.MultidimensionalTimeLineView" addonGroupId="General.AddonGroup" />
+    <addon
+          addonGroupId="General.AddonGroup"
+          class="org.eclipse.gemoc.trace.gemoc.traceaddon.GenericTraceEngineAddon"
+          default="false"
+          id="org.eclipse.gemoc.trace.gemoc.traceaddon"
+          name="Generic MultiDimensional Data Trace"
+          openViewIds="org.eclipse.gemoc.addon.multidimensional.timeline.views.timeline.MultidimensionalTimeLineView"
+          shortDescription="Data Trace support for any language">
+       <addon_booleanOption
+             defaultValue="false"
+             id="org.eclipse.gemoc.trace.gemoc.addon_booleanOption"
+             name="Equivalency classes computing"
+             shortDescription="Activate equivalency classes computing during trace recording">
+       </addon_booleanOption>
+       <addon_stringOption
+             id="org.eclipse.gemoc.trace.gemoc.addon_stringOption1"
+             name="Test String option"
+             shortDescription="some description">
+       </addon_stringOption>
+    </addon>
   </extension>
 </plugin>

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
@@ -29,11 +29,6 @@
              name="Equivalency classes computing"
              shortDescription="Activate equivalency classes computing during trace recording (warning this is time consumming on long running models that don&apos;t have equivalent states)">
        </addon_booleanOption>
-       <addon_stringOption
-             id="org.eclipse.gemoc.trace.gemoc.addon_stringOption1"
-             name="Test String option"
-             shortDescription="some description">
-       </addon_stringOption>
     </addon>
   </extension>
 </plugin>

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/plugin.xml
@@ -27,7 +27,7 @@
              defaultValue="false"
              id="org.eclipse.gemoc.trace.gemoc.addon_booleanOption"
              name="Equivalency classes computing"
-             shortDescription="Activate equivalency classes computing during trace recording">
+             shortDescription="Activate equivalency classes computing during trace recording (warning this is time consumming on long running models that don&apos;t have equivalent states)">
        </addon_booleanOption>
        <addon_stringOption
              id="org.eclipse.gemoc.trace.gemoc.addon_stringOption1"

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/AbstractTraceAddon.xtend
@@ -56,6 +56,9 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 	var boolean needTransaction = true
 	BatchModelChangeListener listenerAddon
 	Trace<Step<?>, TracedObject<?>, State<?, ?>> trace
+	
+	
+	protected boolean activateUpdateEquivalenceClasses = true;
 
 	protected abstract def ITraceConstructor constructTraceConstructor(Resource modelResource, Resource traceResource,
 		Map<EObject, TracedObject<?>> exeToTraced)
@@ -84,7 +87,7 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 		if (root instanceof Trace<?, ?, ?>) {
 			trace = root as Trace<Step<?>, TracedObject<?>, State<?, ?>>
 			traceExplorer = new GenericTraceExplorer(trace)
-			traceExtractor = new GenericTraceExtractor(trace)
+			traceExtractor = new GenericTraceExtractor(trace, activateUpdateEquivalenceClasses)
 		} else {
 			traceExplorer = null
 			traceExtractor = null
@@ -138,6 +141,10 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 	override engineAboutToStart(IExecutionEngine<?> engine) {
 		if (_executionContext === null) {
 			_executionContext = engine.executionContext
+			
+			
+			// load addon options from the execution context
+			this.activateUpdateEquivalenceClasses = _executionContext.runConfiguration.getAttribute("org.eclipse.gemoc.trace.gemoc.addon_booleanOption", false);
 
 			val modelResource = _executionContext.resourceModel
 
@@ -174,7 +181,7 @@ abstract class AbstractTraceAddon implements IEngineAddon, IMultiDimensionalTrac
 				trace = root as Trace<Step<?>, TracedObject<?>, State<?, ?>>
 				val stateManager = constructStateManager(modelResource, exeToTraced.inverse)
 				traceExplorer = new GenericTraceExplorer(trace, stateManager)
-				traceExtractor = new GenericTraceExtractor(trace)
+				traceExtractor = new GenericTraceExtractor(trace, activateUpdateEquivalenceClasses)
 				traceListener = new BatchModelChangeListener(EMFResource.getRelatedResources(traceResource))
 				traceNotifier = new GenericTraceNotifier(traceListener)
 				traceNotifier.addListener(traceExtractor)

--- a/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceExtractor.java
+++ b/trace/generator/plugins/org.eclipse.gemoc.trace.gemoc/src/org/eclipse/gemoc/trace/gemoc/traceaddon/GenericTraceExtractor.java
@@ -71,14 +71,17 @@ public class GenericTraceExtractor
 	private final IQualifiedNameProvider nameProvider = new DefaultDeclarativeQualifiedNameProvider();
 	private Map<ITraceViewListener, Set<TraceViewCommand>> listeners = new HashMap<>();
 
+	protected boolean activateUpdateEquivalenceClasses = true;
+	
 	/**
 	 * Constructor
 	 * 
 	 * @param trace
 	 *            The trace
 	 */
-	public GenericTraceExtractor(Trace<Step<?>, TracedObject<?>, State<?, ?>> trace) {
+	public GenericTraceExtractor(Trace<Step<?>, TracedObject<?>, State<?, ?>> trace, boolean ignoreUpdateEquivalenceClasses) {
 		this.trace = trace;
+		this.activateUpdateEquivalenceClasses = ignoreUpdateEquivalenceClasses; 
 		configureDiffEngine();
 	}
 
@@ -560,7 +563,9 @@ public class GenericTraceExtractor
 
 	@Override
 	public void statesAdded(List<State<?, ?>> states) {
-		updateEquivalenceClasses(states);
+		if(activateUpdateEquivalenceClasses) {
+			updateEquivalenceClasses(states);
+		}
 		notifyListeners();
 	}
 


### PR DESCRIPTION
This PR fixes 2 issues:

- https://github.com/eclipse/gemoc-studio-modeldebugging/issues/23 Addon parameters support
- https://github.com/eclipse/gemoc-studio-modeldebugging/issues/156 Optional equivalency classes computing

**Addon parameters support**
It first adds the possibility for addon designer to declare parameters. 
Declaring parameters for an addon is done via the addon extension point.

Currently, it supports boolean and string parameters. Any number of parameter can by defined for an addon.

The UI of the launch configuration will automatically show the addon parameters.

Accessing the addon parameter is possible from the addon via the IExecutionEngine (for example in the engineAboutToStart
```
public void engineAboutToStart(final IExecutionEngine<?> engine) {
   boolean myOption = engine.getExecutionContext().getRunConfiguration().getAttribute("<UID_OF_THE_PARAMETER>", false);
}
``` 
**Optional equivalency classes computing**
using the above feature, this PR adds a boolean parameter to the generic trace addon in order to let the choice to the user to enable/disable the equivalency classes computing.

This is useful in model where no equivalent state exists as this slow down the execution and makes is unusable. This is typically the case  for languages with float runtime data which have a very low probability to find 2 equivalent states.

Defining Equivalency classes computing parameter in the generic addon:
![image](https://user-images.githubusercontent.com/661468/76984838-a88eac00-693f-11ea-8b8b-428de65a5ec7.png)

UI of the launch configuration for the addons:
![image](https://user-images.githubusercontent.com/661468/76985416-792c6f00-6940-11ea-934e-43a10c64065a.png)
In this screenshot 2 addons declare some parameters: a boolean in the multidimensional addon and a string in the Unity addon.






 
