### PR TITLE
Cache sorting of addon on engine status change

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -201,7 +201,7 @@ public abstract class AbstractExecutionEngine<C extends IExecutionContext<R, ?, 
 	}
 
 	protected void notifyEngineStatusChanged(RunStatus newStatus) {
-		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getSortedEngineAddons(EngineEvent.engineStatusChanged)) {
+		for (IEngineAddon addon : getCachedSortedEngineAddons(EngineEvent.engineStatusChanged)) {
 			try {
 				addon.engineStatusChanged(this, newStatus);
 			} catch (Exception e) {


### PR DESCRIPTION
The _EngineStatusChanged_ event occurs very regularly in the concurrent engine. This PR
put this computaiton (and subsequent log message) in cache like other frequent events

contributes to
https://github.com/eclipse/gemoc-studio-modeldebugging/issues/111
