### PR TITLE
Fix TreeViewerHelper resize too often

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.commons.eclipse.ui/src/org/eclipse/gemoc/commons/eclipse/ui/TreeViewerHelper.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.eclipse.ui/src/org/eclipse/gemoc/commons/eclipse/ui/TreeViewerHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Inria and others.
+ * Copyright (c) 2017, 2020 Inria and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,10 +16,26 @@ import org.eclipse.swt.widgets.TreeColumn;
 public class TreeViewerHelper
 {
 
+	/**
+	 * resize all the columns of the tree viewer to their preferred sizes
+	 * @param viewer
+	 * @param force, if false, the resize happens only if the column size is 0
+	 */
+	public static void resizeColumns(TreeViewer viewer, boolean force)
+	{
+	    for (TreeColumn tc : viewer.getTree().getColumns()) {
+	    	if(tc.getWidth() == 0 || force )
+	    		tc.pack();
+		}
+	}
+	
+	/**
+	 * resize all the columns of the tree viewer to their preferred sizes if their size is 0
+	 * @param viewer
+	 */
 	public static void resizeColumns(TreeViewer viewer)
 	{
-	    for (TreeColumn tc : viewer.getTree().getColumns())
-		    tc.pack();
+		resizeColumns(viewer, false);
 	}
 	
 }


### PR DESCRIPTION
The resize of TreeViewer columns now happens only if the column size is 0

The PR also adds a method allowing  to force the resize.

This PR makes the LogicalStep view more user-friendly as it uses this method on every LogicalStep decision.

fix https://github.com/eclipse/gemoc-studio-modeldebugging/issues/166