### PR TITLE
Initial version of Model Execution Protocol framework for GEMOC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ build.acceleo
 .DS_Store
 xtend-gen
 .polyglot.build.properties
+.polyglot.*
+.META-INF_MANIFEST.MF
+feature.xml.takari_issue_192
 

--- a/commons/plugin.xml
+++ b/commons/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/.classpath
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/.project
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.gemoc.commons.utils</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/.settings/org.eclipse.jdt.core.prefs
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/META-INF/MANIFEST.MF
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: GEMOC Commons Utils
+Bundle-SymbolicName: org.eclipse.gemoc.commons.utils
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Inria
+Automatic-Module-Name: org.eclipse.gemoc.commons.utils
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/build.properties
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/src/org/eclipse/gemoc/commons/utils/ExtensibleInputStream.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/src/org/eclipse/gemoc/commons/utils/ExtensibleInputStream.java
@@ -1,0 +1,56 @@
+package org.eclipse.gemoc.commons.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedList;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class ExtensibleInputStream extends InputStream {
+
+	LinkedBlockingQueue<InputStream> messages = new LinkedBlockingQueue<>();
+
+	@Override
+	public int read() throws IOException {
+		
+//		System.out.println("[DEBUG] Read InputStream");
+		
+		waitForMessage();
+		
+		InputStream current = messages.peek();
+		int c = current.read();
+		if(c != -1) {
+			return c;
+		}
+		else {
+//			System.out.println("[DEBUG] End InputStream 2");
+			messages.poll();
+			
+			waitForMessage();
+			
+			current = messages.peek();
+			return current.read();
+		}
+	}
+	
+	public void addMessage(String message) {
+//		System.out.println("[DEBUG] Fill InputStream");
+		messages.add(new ByteArrayInputStream(message.getBytes()));
+		synchronized (this) {
+			this.notify();
+		}
+	}
+	
+	public void waitForMessage() {
+		if(messages.isEmpty()) {
+			try {
+				synchronized (this) {
+					this.wait();
+				}
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+//			System.out.println("[DEBUG] Wait");
+		}
+	}
+}

--- a/commons/plugins/org.eclipse.gemoc.commons.utils/src/org/eclipse/gemoc/commons/utils/ModelAwarePrintStream.java
+++ b/commons/plugins/org.eclipse.gemoc.commons.utils/src/org/eclipse/gemoc/commons/utils/ModelAwarePrintStream.java
@@ -1,0 +1,212 @@
+package org.eclipse.gemoc.commons.utils;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Locale;
+
+public class ModelAwarePrintStream extends PrintStream {
+	
+	private PrintStream baseStream;
+	private Thread modelExecutionThread;
+	
+	public ModelAwarePrintStream(OutputStream out, PrintStream baseStream) {
+		super(out);
+		this.baseStream = baseStream;
+	}
+	
+	public void registerModelExecutionThread(Thread modelExecutionThread) {
+		this.modelExecutionThread = modelExecutionThread;
+	}
+
+	@Override
+	public void print(boolean b) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(b);
+		} else {
+			this.baseStream.print(b);
+		}
+	}
+
+	@Override
+	public void print(char c) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(c);
+		} else {
+			this.baseStream.print(c);
+		}
+	}
+
+	@Override
+	public void print(int i) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(i);
+		} else {
+			this.baseStream.print(i);
+		}
+	}
+
+	@Override
+	public void print(long l) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(l);
+		} else {
+			this.baseStream.print(l);
+		}
+	}
+
+	@Override
+	public void print(float f) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(f);
+		} else {
+			this.baseStream.print(f);
+		}
+	}
+
+	@Override
+	public void print(double d) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(d);
+		} else {
+			this.baseStream.print(d);
+		}
+	}
+
+	@Override
+	public void print(char[] s) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(s);
+		} else {
+			this.baseStream.print(s);
+		}
+	}
+
+	@Override
+	public void print(String s) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(s);
+		} else {
+			this.baseStream.print(s);
+		}
+	}
+
+	@Override
+	public void print(Object obj) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.print(obj);
+		} else {
+			this.baseStream.print(obj);
+		}
+	}
+
+	@Override
+	public void println() {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println();
+		} else {
+			this.baseStream.println();
+		}
+	}
+
+	@Override
+	public void println(boolean x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(char x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+	
+	@Override
+	public void println(int x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(long x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(float x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(double x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(char[] x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(String x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public void println(Object x) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			super.println(x);
+		} else {
+			this.baseStream.println(x);
+		}
+	}
+
+	@Override
+	public PrintStream printf(String format, Object... args) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			return super.printf(format, args);
+		} else {
+			return this.baseStream.printf(format, args);
+		}
+	}
+
+	@Override
+	public PrintStream printf(Locale l, String format, Object... args) {
+		if (Thread.currentThread() == this.modelExecutionThread) {
+			return super.printf(l, format, args);
+		} else {
+			return this.baseStream.printf(l, format, args);
+		}
+	}
+	
+	
+
+}

--- a/commons/plugins/pom.xml
+++ b/commons/plugins/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.eclipse.gemoc.commons</groupId>
+    <artifactId>org.eclipse.gemoc.commons.plugins.root</artifactId>
+    <packaging>pom</packaging>    
+	<parent>
+		<groupId>org.eclipse.gemoc.commons</groupId>
+		<artifactId>org.eclipse.gemoc.commons.root</artifactId>
+    	<version>3.0.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+    <modules>
+        <!-- pomless plugins -->
+		<module>org.eclipse.gemoc.commons.utils</module>
+    </modules>
+</project>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -34,6 +34,9 @@
         <module>plugins/org.jaxen</module>
         <module>plugins/org.jdom2</module>
         
+        <!-- pomless plugins -->
+        <module>plugins</module>
+        
         <!-- feature and update site -->
         <module>releng</module>
         

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.classpath
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.classpath
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.project
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.project
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.gemoc.executionframework.mep</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.core.resources.prefs
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,6 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,7 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory=src/test/generated-sources/xtend
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
@@ -1,0 +1,76 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.gemoc.executionframework</groupId>
+	<artifactId>org.eclipse.gemoc.executionframework.mep</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	
+	<parent>
+		<groupId>org.eclipse.gemoc.executionframework</groupId>
+    	<artifactId>org.eclipse.gemoc.executionframework.pomfirst</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	
+	<properties>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+	    <surefire-plugin.version>2.22.0</surefire-plugin.version>
+	    <quarkus.version>0.21.1</quarkus.version>
+	    <xtend.version>2.14.0</xtend.version>
+	</properties>
+
+
+	<dependencies>
+
+<!-- 		<dependency> -->
+<!-- 			<groupId>io.quarkus</groupId> -->
+<!-- 			<artifactId>quarkus-resteasy</artifactId> -->
+<!-- 		</dependency> -->
+<!-- 		<dependency> -->
+<!-- 			<groupId>io.quarkus</groupId> -->
+<!-- 			<artifactId>quarkus-junit5</artifactId> -->
+<!-- 			<scope>test</scope> -->
+<!-- 		</dependency> -->
+<!-- 		<dependency> -->
+<!-- 			<groupId>io.rest-assured</groupId> -->
+<!-- 			<artifactId>rest-assured</artifactId> -->
+<!-- 			<scope>test</scope> -->
+<!-- 		</dependency> -->
+<!-- 		<dependency> -->
+<!-- 			<groupId>io.quarkus</groupId> -->
+<!-- 			<artifactId>quarkus-undertow-websockets</artifactId> -->
+<!-- 		</dependency> -->
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext</artifactId>
+			<version>${xtend.version}</version>
+		</dependency>
+<!-- 		<dependency> -->
+<!-- 			<groupId>org.eclipse.xtext</groupId> -->
+<!-- 			<artifactId>org.eclipse.xtext.ide</artifactId> -->
+<!-- 			<version>${xtend.version}</version> -->
+<!-- 		</dependency> -->
+		<dependency>
+			<groupId>org.eclipse.lsp4j</groupId>
+			<artifactId>org.eclipse.lsp4j.debug</artifactId>
+			<version>0.8.0</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.eclipse.gemoc.modeldebugging.framework.commons</groupId>
+			<artifactId>org.eclipse.gemoc.xdsmlframework.api</artifactId>
+			<version>4.0.0-SNAPSHOT</version>
+			<type>eclipse-plugin</type>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			
+		</plugins>
+	</build>
+
+</project>

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
@@ -1,0 +1,290 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
+import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolServer;
+import org.eclipse.gemoc.executionframework.mep.services.ModelExecutionClientAware;
+import org.eclipse.lsp4j.debug.Capabilities;
+import org.eclipse.lsp4j.debug.InitializeRequestArguments;
+import org.eclipse.lsp4j.debug.NextArguments;
+import org.eclipse.lsp4j.debug.TerminateArguments;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
+
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.Pair;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
+
+abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServer, Endpoint, JsonRpcMethodProvider, ModelExecutionClientAware {
+
+	private static final Logger LOG = Logger.getLogger(GemocMEPServerImpl.class);
+
+	private Map<String, JsonRpcMethod> supportedMethods;
+	
+	//private final Multimap<String, Endpoint> extensionProviders = LinkedListMultimap.create();
+	
+	private IModelExecutionProtocolClient client;
+	
+	
+	@Override
+	public Map<String, JsonRpcMethod> supportedMethods() {
+		if (supportedMethods != null) {
+			return supportedMethods;
+		}
+		//synchronized (extensionProviders) {
+			Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<>();
+			supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(getClass()));
+
+			for(JsonRpcMethod supportedMethod : supportedMethods.values()) {
+				LOG.info("supported method "+supportedMethod.getMethodName()+ " "+supportedMethod.getParameterTypes());
+			}
+			/*
+			Map<String, JsonRpcMethod> extensions = new LinkedHashMap<>();
+			for (IResourceServiceProvider resourceServiceProvider : getAllLanguages()) {
+				ILanguageServerExtension ext = resourceServiceProvider.get(ILanguageServerExtension.class);
+				if (ext != null) {
+					ext.initialize(access);
+					Map<String, JsonRpcMethod> supportedExtensions = ext instanceof JsonRpcMethodProvider
+							? ((JsonRpcMethodProvider) ext).supportedMethods()
+							: ServiceEndpoints.getSupportedMethods(ext.getClass());
+					for (Map.Entry<String, JsonRpcMethod> entry : supportedExtensions.entrySet()) {
+						if (supportedMethods.containsKey(entry.getKey())) {
+							LOG.error("The json rpc method \'" + entry.getKey()
+									+ "\' can not be an extension as it is already defined in the LSP standard.");
+						} else {
+							JsonRpcMethod existing = extensions.put(entry.getKey(), entry.getValue());
+							if (existing != null && !Objects.equal(existing, entry.getValue())) {
+								LOG.error("An incompatible LSP extension \'" + entry.getKey()
+										+ "\' has already been registered. Using 1 ignoring 2. \n1 : " + existing
+										+ " \n2 : " + entry.getValue());
+								extensions.put(entry.getKey(), existing);
+							} else {
+								Endpoint endpoint = ServiceEndpoints.toEndpoint(ext);
+								extensionProviders.put(entry.getKey(), endpoint);
+								supportedMethods.put(entry.getKey(), entry.getValue());
+							}
+						}
+					}
+				}
+			}
+			*/
+			this.supportedMethods = supportedMethods;
+			return supportedMethods;
+		//}
+	}
+
+	@Override
+	public void notify(String method, Object parameter) {
+	/*	for (Endpoint endpoint : extensionProviders.get(method)) {
+			try {
+				endpoint.notify(method, parameter);
+			} catch (UnsupportedOperationException e) {
+				if (e != ILanguageServerExtension.NOT_HANDLED_EXCEPTION) {
+					throw e;
+				}
+			}
+		}*/
+		LOG.info("notify "+method);
+	}
+
+	@Override
+	public CompletableFuture<?> request(String method, Object parameter) {
+	/*	if (!extensionProviders.containsKey(method)) {
+			throw new UnsupportedOperationException("The json request \'" + method + "\' is unknown.");
+		}
+		for (Endpoint endpoint : extensionProviders.get(method)) {
+			try {
+				return endpoint.request(method, parameter);
+			} catch (UnsupportedOperationException e) {
+				if (e != ILanguageServerExtension.NOT_HANDLED_EXCEPTION) {
+					throw e;
+				}
+			}
+		}*/
+		throw new UnsupportedOperationException("The json request \'" + method + "\' is unknown.");
+		//return null;
+	}
+	
+	@Override
+	public void connect(IModelExecutionProtocolClient client) {
+		this.client = client;
+	}
+
+	
+
+	// ****************
+	// * DAP protocol *
+	// ****************
+	@Override
+	public CompletableFuture<Capabilities> initialize(InitializeRequestArguments args) {
+		LOG.info("CompletableFuture<Capabilities> initialize(InitializeRequestArguments args)");
+		CompletableFuture<Capabilities> future = CompletableFuture.supplyAsync(new Supplier<Capabilities>() {
+			@Override
+			public Capabilities get() {
+				Capabilities capabilities = new Capabilities();
+				capabilities.setSupportsTerminateRequest(true);
+				// TODO declare here DAP capabilities
+				return capabilities;
+			}
+		});
+		return future;
+	}
+
+	
+	
+	@Override
+	public CompletableFuture<Void> launch(Map<String, Object> args) {
+		CompletableFuture<Void> future = CompletableFuture.runAsync(new Runnable() {
+			@Override
+		    public void run() {
+				// TODO launch the engine
+			//	throw new Exception("failed to launch with args\'" + args + "\'.");
+				LOG.info("launch received with args "+args);
+				
+				Resource res =  null;
+				if (args.containsKey(MEPLaunchParameterKey.modelContent.name())) {
+					try {
+						ResourceSet rs = createResourceSet();
+						InputStream in = new ByteArrayInputStream("type foo type bar".getBytes());
+						res = rs.createResource(URI.createURI("dummy:/example.k3fsm"));
+					
+						res.load(in, rs.getLoadOptions());
+					
+						//Model model = (Model) resource.getContents().get(0);
+						LOG.info("root element in model-content is "+res.getContents().get(0));
+						
+					} catch (IOException e) {
+						LOG.error(e.getMessage(), e);
+					}
+				}
+				if(args.containsKey(MEPLaunchParameterKey.modelURI.name())) {
+					String modelURIString = (String) args.get(MEPLaunchParameterKey.modelURI.name());
+					URI uri = URI.createURI(modelURIString);
+					ResourceSet rs = createResourceSet();
+					res = rs.createResource(uri);
+					try {
+						res.load(rs.getLoadOptions());
+						res.getContents().get(0);
+					LOG.info("root element in model uri is "+res.getContents().get(0));
+					} catch (IOException e) {
+						LOG.error(e.getMessage(), e);
+					}
+				}
+				String languageName = "K3FSM";
+				if(args.containsKey(MEPLaunchParameterKey.language.name())) {
+					languageName = (String) args.get(MEPLaunchParameterKey.language.name());
+				}
+				
+				String methodEntryPoint = "";
+				if(args.containsKey(MEPLaunchParameterKey.methodEntryPoint.name())) {
+					methodEntryPoint = (String) args.get(MEPLaunchParameterKey.methodEntryPoint.name());
+				}
+				String initializationMethod = "";
+				if(args.containsKey(MEPLaunchParameterKey.initializationMethod.name())) {
+					initializationMethod = (String) args.get(MEPLaunchParameterKey.initializationMethod.name());
+				}
+
+				String modelEntryPoint = "/";
+				if(args.containsKey(MEPLaunchParameterKey.modelEntryPoint.name())) {
+					modelEntryPoint = (String) args.get(MEPLaunchParameterKey.modelEntryPoint.name());
+				}
+				String initializationArguments = "/";
+				if(args.containsKey(MEPLaunchParameterKey.initializationArguments.name())) {
+					initializationArguments = (String) args.get(MEPLaunchParameterKey.initializationArguments.name());
+				}
+				launchGemocEngine(res, 
+						languageName, 
+						modelEntryPoint, 
+						methodEntryPoint, //methodEntryPoint, 
+						initializationMethod, //initializationMethod, 
+						initializationArguments); //initializationMethodArgs
+			}
+		});
+		
+		return future;
+	}
+
+	
+	
+	@Override
+	public CompletableFuture<Void> next(NextArguments args) {
+		CompletableFuture<Void> future = CompletableFuture.runAsync(new Runnable() {
+			@Override
+		    public void run() {
+				internalNext();
+			}
+		});
+		return future;
+	}
+	
+	protected abstract void internalNext();
+
+	@Override
+	public CompletableFuture<Void> terminate(TerminateArguments args) {
+		CompletableFuture<Void> future = CompletableFuture.runAsync(new Runnable() {
+			@Override
+		    public void run() {
+				// TODO kill the engine
+				internalTerminate();
+			}
+		});
+		return future;
+	}
+
+	protected abstract void internalTerminate();
+	
+	/**
+	 * create a resource set
+	 * by default it only allows to load xmi models
+	 * @return
+	 */
+	public ResourceSet createResourceSet() {
+		//ResourceSetFactory.createFactory().createResourceSet(modelURI);
+		return new ResourceSetImpl();
+	}
+
+	
+	
+	/**
+	 * 
+	 * @param resourceModel
+	 * @param selectedLanguage
+	 * @param modelEntryPoint
+	 * @param methodEntryPoint
+	 * @param initializationMethod
+	 * @param initializationMethodArgs
+	 */
+	abstract public  void launchGemocEngine(Resource resourceModel, String selectedLanguage, String modelEntryPoint,
+			String methodEntryPoint, String initializationMethod, String initializationMethodArgs);
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLaunchParameterKey.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLaunchParameterKey.java
@@ -1,0 +1,14 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+
+public enum MEPLaunchParameterKey {
+  modelContent, 
+  modelURI,
+  workspaceLocation, // location of the eclipse workspace on the server ie. for resolution of platform:/resource uri
+  language,
+  modelEntryPoint,
+  methodEntryPoint,
+  initializationMethod,
+  initializationArguments
+  
+  
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLaunchParameterKey.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLaunchParameterKey.java
@@ -1,6 +1,7 @@
 package org.eclipse.gemoc.executionframework.mep.launch;
 
 public enum MEPLaunchParameterKey {
+  noDebug,
   modelContent, 
   modelURI,
   workspaceLocation, // location of the eclipse workspace on the server ie. for resolution of platform:/resource uri

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncher.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncher.java
@@ -1,0 +1,227 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
+import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolServer;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint;
+import org.eclipse.lsp4j.jsonrpc.debug.DebugRemoteEndpoint;
+import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
+import org.eclipse.lsp4j.jsonrpc.validation.ReflectiveMessageValidator;
+
+import com.google.gson.GsonBuilder;
+
+/**
+ * Specialized launcher for the MEP Server Protocol.
+ */
+public class MEPLauncher {
+	
+	private MEPLauncher() {}
+	
+	
+	
+	/**
+	 * Create a new Launcher for a given local service object, a given remote
+	 * interface and an input and output stream.
+	 *
+	 * @param localService
+	 *            - an object on which classes RPC methods are looked up
+	 * @param remoteInterface
+	 *            - an interface on which RPC methods are looked up
+	 * @param in
+	 *            - inputstream to listen for incoming messages
+	 * @param out
+	 *            - outputstream to send outgoing messages
+	 */
+	public static <T> Launcher<T> createLauncher(Object localService, Class<T> remoteInterface, InputStream in,
+			OutputStream out) {
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.create();
+	}
+
+	/**
+	 * Create a new Launcher for a given local service object, a given remote
+	 * interface and an input and output stream, and set up message validation and
+	 * tracing.
+	 *
+	 * @param localService
+	 *            - an object on which classes RPC methods are looked up
+	 * @param remoteInterface
+	 *            - an interface on which RPC methods are looked up
+	 * @param in
+	 *            - inputstream to listen for incoming messages
+	 * @param out
+	 *            - outputstream to send outgoing messages
+	 * @param validate
+	 *            - whether messages should be validated with the
+	 *            {@link ReflectiveMessageValidator}
+	 * @param trace
+	 *            - a writer to which incoming and outgoing messages are traced, or
+	 *            {@code null} to disable tracing
+	 */
+	public static <T> Launcher<T> createLauncher(Object localService, Class<T> remoteInterface, InputStream in,
+			OutputStream out, boolean validate, PrintWriter trace) {
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.validateMessages(validate)
+				.traceMessages(trace)
+				.create();
+	}
+
+	/**
+	 * Create a new Launcher for a given local service object, a given remote
+	 * interface and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and
+	 * outgoing message streams so additional message handling such as validation
+	 * and tracing can be included.
+	 *
+	 * @param localService
+	 *            - an object on which classes RPC methods are looked up
+	 * @param remoteInterface
+	 *            - an interface on which RPC methods are looked up
+	 * @param in
+	 *            - inputstream to listen for incoming messages
+	 * @param out
+	 *            - outputstream to send outgoing messages
+	 * @param executorService
+	 *            - the executor service used to start threads
+	 * @param wrapper
+	 *            - a function for plugging in additional message consumers
+	 */
+	public static <T> Launcher<T> createLauncher(Object localService, Class<T> remoteInterface, InputStream in,
+			OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
+		return createIoLauncher(localService, remoteInterface, in, out, executorService, wrapper);
+	}
+
+	/**
+	 * Create a new Launcher for a given local service object, a given remote
+	 * interface and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and
+	 * outgoing message streams so additional message handling such as validation
+	 * and tracing can be included.
+	 *
+	 * @param localService
+	 *            - an object on which classes RPC methods are looked up
+	 * @param remoteInterface
+	 *            - an interface on which RPC methods are looked up
+	 * @param in
+	 *            - inputstream to listen for incoming messages
+	 * @param out
+	 *            - outputstream to send outgoing messages
+	 * @param executorService
+	 *            - the executor service used to start threads
+	 * @param wrapper
+	 *            - a function for plugging in additional message consumers
+	 */
+	public static <T> Launcher<T> createIoLauncher(Object localService, Class<T> remoteInterface, InputStream in,
+			OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.create();
+	}
+
+	/**
+	 * Create a new Launcher for a given local service object, a given remote
+	 * interface and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and
+	 * outgoing message streams so additional message handling such as validation
+	 * and tracing can be included. The {@code configureGson} function can be used
+	 * to register additional type adapters in the {@link GsonBuilder} in order to
+	 * support protocol classes that cannot be handled by Gson's reflective
+	 * capabilities.
+	 *
+	 * @param localService
+	 *            - an object on which classes RPC methods are looked up
+	 * @param remoteInterface
+	 *            - an interface on which RPC methods are looked up
+	 * @param in
+	 *            - inputstream to listen for incoming messages
+	 * @param out
+	 *            - outputstream to send outgoing messages
+	 * @param executorService
+	 *            - the executor service used to start threads
+	 * @param wrapper
+	 *            - a function for plugging in additional message consumers
+	 * @param configureGson
+	 *            - a function for Gson configuration
+	 */
+	public static <T> Launcher<T> createIoLauncher(Object localService, Class<T> remoteInterface, InputStream in,
+			OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper,
+			Consumer<GsonBuilder> configureGson) {
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.configureGson(configureGson)
+				.create();
+	}
+	
+	/**
+	 * Launcher builder for the debug protocol. Adapts the JSON-RPC message classes to the JSON format used
+	 * by the debug protocol.
+	 */
+	public static class Builder<T> extends Launcher.Builder<T> {
+		
+		@Override
+		protected MessageJsonHandler createJsonHandler() {
+			Map<String, JsonRpcMethod> supportedMethods = getSupportedMethods();
+			if (configureGson != null)
+				return new DebugMessageJsonHandler(supportedMethods, configureGson);
+			else
+				return new DebugMessageJsonHandler(supportedMethods);
+		}
+		
+		@Override
+		protected RemoteEndpoint createRemoteEndpoint(MessageJsonHandler jsonHandler) {
+			try {
+			MessageConsumer outgoingMessageStream = new StreamMessageConsumer(output, jsonHandler);
+			outgoingMessageStream = wrapMessageConsumer(outgoingMessageStream);
+			Endpoint localEndpoint = ServiceEndpoints.toEndpoint(localServices);
+			RemoteEndpoint remoteEndpoint;
+			
+			// !!!! nosuchfieldException that is trapped by quarkus
+			// check if this is a version issue ?
+			if (exceptionHandler == null)
+				remoteEndpoint = new MEPRemoteEndpoint(outgoingMessageStream, localEndpoint);
+			else
+				remoteEndpoint = new MEPRemoteEndpoint(outgoingMessageStream, localEndpoint, exceptionHandler);
+			jsonHandler.setMethodProvider(remoteEndpoint);
+			return remoteEndpoint;
+			} catch (Exception e) {
+				System.out.println("   issue in createRemoteEndpoint"+e);
+				e.printStackTrace();
+				return null;
+			}
+		}
+		
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncherParameters.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncherParameters.java
@@ -1,0 +1,13 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+
+import org.eclipse.emf.ecore.resource.Resource;
+
+public class MEPLauncherParameters {
+	
+	public Resource resourceModel = null;
+	public String modelEntryPoint = "";
+	public String methodEntryPoint = "";
+	public String initializationMethod = "";
+	public String initializationMethodArgs = "";
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPRemoteEndpoint.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPRemoteEndpoint.java
@@ -1,0 +1,21 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+
+import java.util.function.Function;
+
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.debug.DebugRemoteEndpoint;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+
+public class MEPRemoteEndpoint extends DebugRemoteEndpoint {
+
+	public MEPRemoteEndpoint(MessageConsumer out, Endpoint localEndpoint) {
+		super(out, localEndpoint);
+	}
+	
+	public MEPRemoteEndpoint(MessageConsumer out, Endpoint localEndpoint,
+			Function<Throwable, ResponseError> exceptionHandler) {
+		super(out, localEndpoint, exceptionHandler);
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/ModelLoadingMethod.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/ModelLoadingMethod.java
@@ -1,0 +1,6 @@
+package org.eclipse.gemoc.executionframework.mep.launch;
+
+public enum ModelLoadingMethod {
+	uri,
+	modelFileContent
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/IModelExecutionProtocolClient.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/IModelExecutionProtocolClient.java
@@ -1,0 +1,12 @@
+package org.eclipse.gemoc.executionframework.mep.services;
+
+import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
+
+/**
+ * Declaration of client notifications for the
+ * <a href="https://microsoft.github.io/debug-adapter-protocol/">Debug Adapter
+ * Protocol</a> and its Model Execution Protocol extension
+ */
+public interface IModelExecutionProtocolClient extends IDebugProtocolClient {
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/IModelExecutionProtocolServer.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/IModelExecutionProtocolServer.java
@@ -1,0 +1,12 @@
+package org.eclipse.gemoc.executionframework.mep.services;
+
+import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
+
+/**
+ * Declaration of server requests for the
+ * <a href="https://microsoft.github.io/debug-adapter-protocol/">Debug Adapter
+ * Protocol</a> extended with Model Execution Protocol
+ */
+public interface IModelExecutionProtocolServer extends IDebugProtocolServer {
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/ModelExecutionClientAware.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/services/ModelExecutionClientAware.java
@@ -1,0 +1,6 @@
+package org.eclipse.gemoc.executionframework.mep.services;
+
+public interface ModelExecutionClientAware {
+
+	void connect(IModelExecutionProtocolClient client);
+}

--- a/framework/execution_framework/pomfirst/pom.xml
+++ b/framework/execution_framework/pomfirst/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+    http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.gemoc.executionframework</groupId>
+	<artifactId>org.eclipse.gemoc.executionframework.pomfirst</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.eclipse.gemoc</groupId>
+		<artifactId>org.eclipse.gemoc.modeldebugging.pomfirst</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../../../pomfirst/pom.xml</relativePath>
+	</parent>
+
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>org.eclipse.gemoc.executionframework.mep</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<!-- enable xtend compilation -->
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+				<version>${xtend.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>xtend-install-debug-info</goal>
+							<goal>testCompile</goal>
+							<goal>xtend-test-install-debug-info</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>xtend-gen</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<!-- workaround https://github.com/eclipse/xtext/issues/1231 -->
+				<!-- workaround https://github.com/eclipse/xtext/issues/1373 -->
+				<!-- Remove with upgrade to Xtext 2.15 -->
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>3.13.102</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+						<version>1.3.110</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+						<version>1.2.101</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.emf</groupId>
+						<artifactId>org.eclipse.emf.codegen</artifactId>
+						<version>2.11.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -1,0 +1,108 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+    http://maven.apache.org/maven-v4_0_0.xsd"> 
+
+    <modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.gemoc</groupId>
+    <artifactId>org.eclipse.gemoc.modeldebugging.pomfirst</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+ 
+    <packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>1.6.0</tycho.version>
+		<xtend.version>2.19.0</xtend.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
+		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	
+		
+	<modules>
+        <module>../framework/execution_framework/pomfirst</module>
+    </modules>
+	
+	<build>
+		<plugins>
+			<!-- enable P2 layout for repositories -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<!-- enable xtend compilation -->
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+				<version>${xtend.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>xtend-install-debug-info</goal>
+							<goal>testCompile</goal>
+							<goal>xtend-test-install-debug-info</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>xtend-gen</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<!-- workaround https://github.com/eclipse/xtext/issues/1231 -->
+				<!-- workaround https://github.com/eclipse/xtext/issues/1373 -->
+				<!-- Remove with upgrade to Xtext 2.15 -->
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>3.13.102</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+						<version>1.3.110</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+						<version>1.2.101</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.emf</groupId>
+						<artifactId>org.eclipse.emf.codegen</artifactId>
+						<version>2.11.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+
+		</plugins>
+	</build>
+	
+	<repositories>
+		<repository>
+			<id>nexus-eclipse-gemoc</id>
+			<name>Nexus Eclipse GEMOC</name>
+			<releases><enabled>true</enabled></releases>
+			<snapshots><enabled>true</enabled></snapshots>
+			<url>https://repo.eclipse.org/content/groups/gemoc/</url>
+		</repository>
+		
+		<repository>
+			<id>eclipse-repo</id>
+			<url>${eclipse-repo.url}</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>gemoc-repo</id>
+			<url>${gemoc-repo.url}</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+</project>


### PR DESCRIPTION
This PR contributes some reusable elements to implement a Model Execution Protocol (Debug Adapter Protocol) in GEMOC

This first PR adds:
- a plugin offering a printstream that allow to redirect the stream if it comes from a given thread  (note: this should be used later in the messaging system too)
- a  maven project (_org.eclipse.gemoc.executionframework.mep_) providing the base classes of a MEP server. It mainly provides abstract classes that specific engines must implement.
This project is intended to run in a pure maven build. It uses maven dependencies instead of plugin/manifest (ie. it doesn't use tycho) as tycho dependencies and maven dependencies cannot be built in the same reactor, the pom are in specific folders (named _pomfirst_) 
