### PR TITLE
Kermeta3 validation rule moved into gemoc-debugging from the K3 validation plugin

### DIFF
--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.classpath
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.project
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.gemoc.xdsmlframework.extensions.kermeta3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/META-INF/MANIFEST.MF
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Gemoc extension for Kermeta3
+Bundle-SymbolicName: org.eclipse.gemoc.xdsmlframework.extensions.kermeta3;singleton:=true
+Bundle-Version: 4.0.0.qualifier
+Automatic-Module-Name: org.eclipse.gemoc.xdsmlframework.extension.kermeta3
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.core.resources,
+ org.eclipse.equinox.registry,
+ org.eclipse.gemoc.dsl;bundle-version="3.0.0",
+ org.eclipse.gemoc.xdsmlframework.api;bundle-version="4.0.0",
+ org.eclipse.jdt.core;bundle-version="3.14.0"
+Export-Package: org.eclipse.gemoc.xdsmlframework.extensions.kermeta3

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/build.properties
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/plugin.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+
+</plugin>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/pom.xml
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Inria and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Inria - initial API and implementation
+ -->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <relativePath>../..</relativePath>
+    <groupId>org.eclipse.gemoc.modeldebugging.xdsmlframework</groupId>
+    <artifactId>org.eclipse.gemoc.modeldebugging.xdsmlframework.root</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.eclipse.gemoc.xdsmlframework.extensions.kermeta3</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/src/org/eclipse/gemoc/xdsmlframework/extensions/kermeta3/Kermeta3Rule.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3/src/org/eclipse/gemoc/xdsmlframework/extensions/kermeta3/Kermeta3Rule.java
@@ -1,0 +1,95 @@
+package org.eclipse.gemoc.xdsmlframework.extensions.kermeta3;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.gemoc.dsl.Dsl;
+import org.eclipse.gemoc.dsl.Entry;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.IRule;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.Message;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.Severity;
+import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
+public class Kermeta3Rule implements IRule{
+	
+	boolean tagTests; 
+	
+	public Kermeta3Rule(boolean performsTagTest) {
+		tagTests = performsTagTest;
+	}
+
+	@Override
+	public Message execute(Dsl dsl) {
+		ArrayList<String> entriesNames = new ArrayList<String>();
+		
+		for (Entry e : dsl.getEntries()) {
+			entriesNames.add(e.getKey());
+		}
+		
+		if(!entriesNames.contains("k3")) {
+			return (new Message("Missing entry \"k3\"", Severity.ERROR));
+		}
+			
+		return (new Message("",Severity.DEFAULT));
+	}
+
+	@Override
+	public Message execute(Entry entry) {
+		if("k3".matches(entry.getKey())) {
+			String aspectsFields = entry.getValue();
+			
+			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+			IFile file = root.getFile(new Path(entry.eResource().getURI().toPlatformString(true)));
+			
+			IProject proj = file.getProject();
+			IJavaProject jProj = JavaCore.create(proj);
+			
+			if(jProj == null) {
+				return (new Message("No project dsa in the workspace", Severity.ERROR));
+			}
+			
+			ArrayList<String> aspectsName = new ArrayList<>();
+			ArrayList<String> aspectsAnnotation = new ArrayList<>();
+			
+			for(String s : aspectsFields.split(",")) {
+				aspectsName.add(s.trim());
+			}
+			
+			
+			for(String asp : aspectsName) {
+				try {
+					IType type = jProj.findType(asp);
+					for(IMethod meth : type.getMethods()) {
+						for(IAnnotation annot : meth.getAnnotations()) {
+							aspectsAnnotation.add(annot.getElementName());
+						}
+					}
+				} catch (Exception e) {
+					return (new Message("No aspect matching \""+asp+ "\" in the project", Severity.ERROR));
+				}
+			}
+			
+			if(tagTests) {
+				
+				if(!aspectsAnnotation.contains("Main")) {
+					return (new Message("No method annotated with \"Main\" in the project", Severity.ERROR));
+				}
+				
+				if(!aspectsAnnotation.contains("InitializeModel")) {
+					return (new Message("No method annotated with \"InitializeModel\" in the project", Severity.WARNING));
+				}
+				
+			}
+			
+		}
+		return (new Message("", Severity.DEFAULT));
+	}
+}

--- a/framework/xdsml_framework/pom.xml
+++ b/framework/xdsml_framework/pom.xml
@@ -18,7 +18,8 @@
         <!-- plugins -->
         <module>plugins/org.eclipse.gemoc.xdsmlframework.ui.utils</module>
         <module>plugins/org.eclipse.gemoc.xdsmlframework.ide.ui</module>        
-        <module>plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius</module>    
+        <module>plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius</module>
+        <module>plugins/org.eclipse.gemoc.xdsmlframework.extensions.kermeta3</module>   
         <module>tests/org.eclipse.gemoc.xdsmlframework.test.lib</module> 
 
         <!-- feature -->


### PR DESCRIPTION
K3 validation rule moved to reduce code duplication between K3 validation plug-in  and MOCCML validation plug-in.

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>