### PR TITLE
New RuleProvider for Ecore and FullyQualifiedName with it

### DIFF
--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
@@ -25,4 +25,11 @@
             id="General.AddonGroup">
       </addonGroup>
    </extension>
+   <extension
+         point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
+      <approach
+            name="org.eclipse.gemoc.metaprog.ecore"
+            validator="org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.EcoreRuleProvider">
+      </approach>
+   </extension>
 </plugin>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/metaprog/EcoreRuleProvider.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/metaprog/EcoreRuleProvider.java
@@ -1,0 +1,19 @@
+package org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class EcoreRuleProvider implements IRuleProvider {
+	
+	private ArrayList<IRule> ruleSet = new ArrayList<IRule>();
+
+	public EcoreRuleProvider() {
+		ruleSet.add(new EcoreRule());
+	}
+
+	@Override
+	public Collection<IRule> getValidationRules() {
+		return ruleSet;
+	}
+
+}


### PR DESCRIPTION
New RuleProvider for dsl that only uses an Ecore meta-model.

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>