### PR TITLE
Proposal Provider and Highlighting for dsl files in GEMOC Studio

### DIFF
--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/META-INF/MANIFEST.MF
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.gemoc.dsl,
  org.eclipse.compare,
  org.eclipse.xtext.builder,
  org.eclipse.xtend.lib;resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.gemoc.xdsmlframework.api;bundle-version="4.0.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.ui.contentassist,

--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
@@ -65,12 +65,12 @@ class DslProposalProvider extends AbstractDslProposalProvider {
 					keys = approach.getChildren("languageComponent")
 					for(IConfigurationElement key: keys){
 						var name = key.getAttribute('name')
-						var optional = key.getChildren('optional')
-						var String displayString = name
+						var optional = key.getAttribute('optional')
+						var String displayString = name + " - "
 						if("true".equals(optional)){
-							displayString = displayString + " (optional)"
+							displayString = displayString + "(optional) "
 						}
-						displayString = displayString + " - " + key.getAttribute("description")
+						displayString = displayString + key.getAttribute("description")
 						if(!dslKeys.contains(name)){
 							acceptor.accept(createCompletionProposal(name, displayString, null,context))
 						}

--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
@@ -12,8 +12,8 @@ import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
 import org.eclipse.gemoc.dsl.Entry
 import org.eclipse.gemoc.dsl.Dsl
 import org.eclipse.xtext.RuleCall
-import org.eclipse.emf.common.util.EList
 import java.util.ArrayList
+import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.LanguageComponentHelper
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#content-assist
@@ -21,6 +21,7 @@ import java.util.ArrayList
  */
 class DslProposalProvider extends AbstractDslProposalProvider {
 	
+	val approachHelper = new LanguageComponentHelper()
 	
 	val IConfigurationElement[] metaprogApproach = Platform.getExtensionRegistry().getConfigurationElementsFor("org.eclipse.gemoc.gemoc_language_workbench.metaprog")
 	
@@ -60,27 +61,20 @@ class DslProposalProvider extends AbstractDslProposalProvider {
 				acceptor.accept(createCompletionProposal("metaprog", displayString, null, context))
 			}
 			
-			for (IConfigurationElement approach : metaprogApproach){
-				if(approach.getAttribute('name').equals(metaprog)){
-					keys = approach.getChildren("languageComponent")
-					for(IConfigurationElement key: keys){
-						var name = key.getAttribute('name')
-						var optional = key.getAttribute('optional')
-						var String displayString = name + " - "
-						if("true".equals(optional)){
-							displayString = displayString + "(optional) "
-						}
-						displayString = displayString + key.getAttribute("description")
-						if(!dslKeys.contains(name)){
-							acceptor.accept(createCompletionProposal(name, displayString, null,context))
-						}
-					}
-					
+			keys = approachHelper.getFullApproachKeys(metaprog)
+			
+			for(IConfigurationElement key : keys){
+				var name = key.getAttribute('name')
+				var optional = key.getAttribute('optional')
+				var String displayString = name + " - "
+				if("true".equals(optional)){
+					displayString = displayString + "(optional) "
+				}
+				displayString = displayString + key.getAttribute("description")
+				if(!dslKeys.contains(name)){
+					acceptor.accept(createCompletionProposal(name, displayString, null,context))
 				}
 			}
 		}
-		
-		
 	}
-
 }

--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/contentassist/DslProposalProvider.xtend
@@ -3,10 +3,40 @@
  */
 package org.eclipse.gemoc.ui.contentassist
 
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.runtime.IConfigurationElement
+import org.eclipse.core.runtime.Platform
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.Assignment
+import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext
+import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
+import org.eclipse.gemoc.dsl.Entry
 
 /**
  * See https://www.eclipse.org/Xtext/documentation/304_ide_concepts.html#content-assist
  * on how to customize the content assistant.
  */
 class DslProposalProvider extends AbstractDslProposalProvider {
+	
+	
+	override completeEntry_Value(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor){
+		super.completeEntry_Value(model, assignment, context, acceptor)
+		
+		val IConfigurationElement[] metaprogApproach = Platform.getExtensionRegistry().getConfigurationElementsFor("org.eclipse.gemoc.gemoc_language_workbench.metaprog")
+		var Entry entry
+		
+		if(model instanceof Entry){
+			entry = model as Entry
+			if("metaprog".equals(entry.key)){
+				try{
+					for (IConfigurationElement approach : metaprogApproach){
+						var name = approach.getAttribute("name")
+						acceptor.accept(createCompletionProposal(name, context))
+					}
+				}catch (CoreException ex){
+					System.out.println(ex.getMessage())
+				}
+			}
+		}
+	}
 }

--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/highlighting/DslHighlightingConfiguration.xtend
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/highlighting/DslHighlightingConfiguration.xtend
@@ -8,6 +8,7 @@ import org.eclipse.swt.SWT
 
 class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 	public static final String KEY_ID = "dsl_key"
+	public static final String KEY_PLUGIN_ID = "plugin_key"
 	public static final String VALUE_ID = "dsl_value"
 	public static final String SEPARATOR_ID = "dsl_separator"
 	public static final String LINESEPARATOR_ID = "dsl_lineseparator"
@@ -15,6 +16,7 @@ class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 	override configure(IHighlightingConfigurationAcceptor acceptor) {
 		super.configure(acceptor)
 		acceptor.acceptDefaultHighlighting(KEY_ID, "Entry key", keyTextStyle());
+		acceptor.acceptDefaultHighlighting(KEY_PLUGIN_ID, "Plugin entry key", pluginKeyTextStyle());
 		acceptor.acceptDefaultHighlighting(VALUE_ID, "Entry value", valueTextStyle());
 		acceptor.acceptDefaultHighlighting(SEPARATOR_ID, "Entry separator", separatorTextStyle());
 		acceptor.acceptDefaultHighlighting(LINESEPARATOR_ID, "Line separator", lineSeparatorTextStyle());
@@ -23,8 +25,16 @@ class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 	def TextStyle keyTextStyle() {
 		val TextStyle textStyle = defaultTextStyle().copy();
 		textStyle.setColor(new RGB(0, 26, 171)); // From org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration.field()
+		
 		// textStyle.setColor(new RGB(171, 48, 0)); // From org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration.extensionMethodInvocation()
 		return textStyle;
+	}
+	
+	def TextStyle pluginKeyTextStyle(){
+		val TextStyle textStyle = defaultTextStyle().copy()
+		textStyle.setColor(new RGB(145, 85, 0))
+		
+		return textStyle
 	}
 
 	def TextStyle valueTextStyle() {

--- a/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/highlighting/DslHighlightingConfiguration.xtend
+++ b/commons/plugins/org.eclipse.gemoc.dsl.ui/src/org/eclipse/gemoc/ui/highlighting/DslHighlightingConfiguration.xtend
@@ -9,6 +9,7 @@ import org.eclipse.swt.SWT
 class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 	public static final String KEY_ID = "dsl_key"
 	public static final String KEY_PLUGIN_ID = "plugin_key"
+	public static final String OPTIONAL_KEY_PLUGIN_ID = "optional_plugin_key"
 	public static final String VALUE_ID = "dsl_value"
 	public static final String SEPARATOR_ID = "dsl_separator"
 	public static final String LINESEPARATOR_ID = "dsl_lineseparator"
@@ -17,6 +18,7 @@ class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 		super.configure(acceptor)
 		acceptor.acceptDefaultHighlighting(KEY_ID, "Entry key", keyTextStyle());
 		acceptor.acceptDefaultHighlighting(KEY_PLUGIN_ID, "Plugin entry key", pluginKeyTextStyle());
+		acceptor.acceptDefaultHighlighting(OPTIONAL_KEY_PLUGIN_ID, "Optional entry key", pluginOptionalKeyTextStyle());
 		acceptor.acceptDefaultHighlighting(VALUE_ID, "Entry value", valueTextStyle());
 		acceptor.acceptDefaultHighlighting(SEPARATOR_ID, "Entry separator", separatorTextStyle());
 		acceptor.acceptDefaultHighlighting(LINESEPARATOR_ID, "Line separator", lineSeparatorTextStyle());
@@ -33,6 +35,14 @@ class DslHighlightingConfiguration extends DefaultHighlightingConfiguration {
 	def TextStyle pluginKeyTextStyle(){
 		val TextStyle textStyle = defaultTextStyle().copy()
 		textStyle.setColor(new RGB(145, 85, 0))
+		
+		return textStyle
+	}
+	
+	def TextStyle pluginOptionalKeyTextStyle(){
+		val TextStyle textStyle = defaultTextStyle().copy()
+		textStyle.setColor(new RGB(145, 85, 0))
+		textStyle.setStyle(SWT.ITALIC);
 		
 		return textStyle
 	}

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
@@ -28,6 +28,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
+            dependencies=""
             name="org.eclipse.gemoc.metaprog.ecore"
             validator="org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.EcoreRuleProvider">
          <languageComponent

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/plugin.xml
@@ -30,6 +30,11 @@
       <approach
             name="org.eclipse.gemoc.metaprog.ecore"
             validator="org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.EcoreRuleProvider">
+         <languageComponent
+               description="Entry used to define the Ecore model used for the language."
+               name="ecore"
+               optional="false">
+         </languageComponent>
       </approach>
    </extension>
 </plugin>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
@@ -69,6 +69,13 @@
                </appinfo>
             </annotation>
          </attribute>
+         <attribute name="dependencies" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
@@ -50,7 +50,7 @@
    <element name="approach">
       <complexType>
          <sequence>
-            <element ref="key" minOccurs="1" maxOccurs="unbounded"/>
+            <element ref="languageComponent" minOccurs="1" maxOccurs="unbounded"/>
          </sequence>
          <attribute name="name" type="string" use="required">
             <annotation>
@@ -72,9 +72,9 @@
       </complexType>
    </element>
 
-   <element name="key">
+   <element name="languageComponent">
       <complexType>
-         <attribute name="optionnal" type="boolean" use="required">
+         <attribute name="optional" type="boolean" use="required">
             <annotation>
                <documentation>
                   
@@ -82,6 +82,13 @@
             </annotation>
          </attribute>
          <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="description" type="string">
             <annotation>
                <documentation>
                   

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/schema/org.eclipse.gemoc.gemoc_language_workbench.metaprog.exsd
@@ -49,6 +49,9 @@
 
    <element name="approach">
       <complexType>
+         <sequence>
+            <element ref="key" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
          <attribute name="name" type="string" use="required">
             <annotation>
                <documentation>
@@ -64,6 +67,25 @@
                <appinfo>
                   <meta.attribute kind="java" basedOn=":org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.IRuleProvider"/>
                </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="key">
+      <complexType>
+         <attribute name="optionnal" type="boolean" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
             </annotation>
          </attribute>
       </complexType>

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/metaprog/LanguageComponentHelper.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/extensions/metaprog/LanguageComponentHelper.java
@@ -1,0 +1,80 @@
+package org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog;
+
+import java.util.ArrayList;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+
+public class LanguageComponentHelper {
+	
+	private IConfigurationElement[] exts = Platform.getExtensionRegistry().getConfigurationElementsFor("org.eclipse.gemoc.gemoc_language_workbench.metaprog");
+	
+	public LanguageComponentHelper() {
+		
+	}
+	
+	
+	public ArrayList<String> getAllMetaprogKeys() {
+		
+		ArrayList<String> allKeys = new ArrayList<String>();
+		
+		for(IConfigurationElement appr : exts) {
+			IConfigurationElement[] keys = appr.getChildren("languageComponent");
+			for (IConfigurationElement key : keys) {
+				allKeys.add(key.getAttribute("name"));
+			}
+		}
+		
+		return allKeys;
+		
+	}
+	
+	
+	public ArrayList<IConfigurationElement> getApproachKeys(IConfigurationElement approach){
+		
+		ArrayList<IConfigurationElement> allKeys = new ArrayList<IConfigurationElement>();
+		
+		for(IConfigurationElement comp : approach.getChildren("languageComponent")) {
+			allKeys.add(comp);
+		}
+		
+		return allKeys;
+	}
+	
+	
+	public ArrayList<IConfigurationElement> getApproachKeys(String approachName){
+		
+		ArrayList<IConfigurationElement> allKeys = new ArrayList<IConfigurationElement>();
+		
+		for (IConfigurationElement appr : exts) {
+			if(approachName.matches(appr.getAttribute("name"))){
+				for(IConfigurationElement comp : appr.getChildren("languageComponent")) {
+					allKeys.add(comp);
+				}
+			}
+		}
+		
+		return allKeys;
+	}
+	
+	
+	public ArrayList<IConfigurationElement> getFullApproachKeys(String approach){
+		
+		ArrayList<IConfigurationElement> allKeys = new ArrayList<IConfigurationElement>();
+		
+		for(IConfigurationElement appr : exts) {
+			if(approach.matches(appr.getAttribute("name"))){
+				allKeys.addAll(getApproachKeys(appr));
+				
+				String[] dependencies = appr.getAttribute("dependencies").split(",");
+				
+				for(String depen : dependencies){
+					allKeys.addAll(getApproachKeys(depen));
+				}
+				
+			}
+		}
+		
+		return allKeys;
+	}
+
+}


### PR DESCRIPTION
To further ease the creation of a DSL, we add a Proposal Provider in GEMOC Studio to give suggestion at various points in the dsl file.

This Proposal Provider gives suggestions to the language engineers when selecting a metaprogramming approach
![metaprog_completion](https://user-images.githubusercontent.com/37030663/84032432-a284f600-a997-11ea-8069-61be4b4058ed.JPG)
and, once the approach is selected, gives suggestion for the entries the approach might need.

We modified the Highlighting for the dsl files to "highlight" the difference between an entry required for all dsl files and an entry required by the approach selected.

![ale_highlight](https://user-images.githubusercontent.com/37030663/84032705-04456000-a998-11ea-9b5b-359839d526d1.png)

In this DSL created in Ale, both the "name" and "metaprog" entries are highlighted in blue while the "ale" and the "ecore" entries are hihjlighted in gold since they both are required by a metaprogramming approach.

For these modification to work, the extension point for the metaprogramming approach was modified to require the plugins contributing to specify a sequence of key. These keys have a nameand a boolean to specify if they are optional or not.
Another modification to the extension point was the addition of a "dependencies" string for the approaches that specifies which approach to load with the one selected.
These modification allow for the metaprogramming approaches present in the GEMOC Studio to have access to the "ecore" key in their Proposal Provider and to color it correctly.

Another addition is the LanguageComponentHelper, this class is used to gather IConfigurationElement from an approach to be used by the aformentioned tools.

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>
