### PR TITLE
Model execution protocol

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/HeadlessJavaEngineSequentialRunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/commons/sequential/HeadlessJavaEngineSequentialRunConfiguration.java
@@ -1,0 +1,110 @@
+package org.eclipse.gemoc.executionframework.engine.commons.sequential;
+
+import java.util.Collection;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
+
+public class HeadlessJavaEngineSequentialRunConfiguration implements ISequentialRunConfiguration {
+
+	URI modelURI;
+	String languageName;
+	String modelEntryPoint;
+	String methodEntryPoint; 
+	String initializationMethod;
+	String initializationMethodArgs;
+	public HeadlessJavaEngineSequentialRunConfiguration(URI modelURI, String languageName, String modelEntryPoint,
+			String methodEntryPoint, String initializationMethod, String initializationMethodArgs) {
+		this.modelURI = modelURI;
+		this.languageName =  languageName;
+		this.modelEntryPoint = modelEntryPoint;
+		this.methodEntryPoint = methodEntryPoint;
+		this.initializationMethod = initializationMethod;
+		this.initializationMethodArgs = initializationMethodArgs;
+	}
+
+	@Override
+	public int getAnimationDelay() {
+		return 0;
+	}
+
+	@Override
+	public URI getAnimatorURI() {
+		return null;
+	}
+
+	@Override
+	public boolean getBreakStart() {
+		return false;
+	}
+
+	@Override
+	public String getDebugModelID() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Collection<EngineAddonSpecificationExtension> getEngineAddonExtensions() {
+		return null;
+	}
+
+	@Override
+	public URI getExecutedModelAsMelangeURI() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public URI getExecutedModelURI() {
+		return modelURI;
+	}
+
+	@Override
+	public String getLanguageName() {
+		return this.languageName;
+	}
+
+	@Override
+	public String getMelangeQuery() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getExecutionEntryPoint() {
+		return this.methodEntryPoint;
+	}
+
+	@Override
+	public String getModelEntryPoint() {
+		return this.modelEntryPoint;
+	}
+
+	@Override
+	public String getModelInitializationMethod() {
+		return this.initializationMethod;
+	}
+
+	@Override
+	public String getModelInitializationArguments() {
+		return this.initializationMethodArgs;
+	}
+	
+	
+	public String getAttribute(String attributeName, String defaultValue) {
+		// there is no addon in this mode, so return the default value
+		return defaultValue;
+	}
+
+	public Integer getAttribute(String attributeName, Integer defaultValue) {
+		// there is no addon in this mode, so return the default value
+		return defaultValue;
+	}
+
+	public Boolean getAttribute(String attributeName, Boolean defaultValue) {
+		// there is no addon in this mode, so return the default value
+		return defaultValue;
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
@@ -57,6 +57,27 @@
 			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.lsp4j</groupId>
+			<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
+			<version>0.8.0</version>
+		</dependency>
+		
+		<dependency>
+    		<groupId>org.eclipse.emf</groupId>
+    		<artifactId>org.eclipse.emf.edit</artifactId>
+    		<version>2.16.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.gemoc.commons</groupId>
+			<artifactId>org.eclipse.gemoc.commons.eclipse.pde</artifactId>
+			<version>3.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.gemoc.commons</groupId>
+			<artifactId>org.eclipse.gemoc.commons.eclipse.messagingsystem.api</artifactId>
+			<version>3.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.gemoc.pomfirst</groupId>
 			<artifactId>org.eclipse.gemoc.xdsmlframework.api</artifactId>
 			<version>4.0.0-SNAPSHOT</version>

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/pom.xml
@@ -47,16 +47,6 @@
 			<version>2.16.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.gemoc.commons</groupId>
-			<artifactId>org.eclipse.gemoc.commons.eclipse.pde</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.gemoc.commons</groupId>
-			<artifactId>org.eclipse.gemoc.commons.eclipse.messagingsystem.api</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
 			<version>0.8.0</version>
@@ -66,26 +56,6 @@
     		<groupId>org.eclipse.emf</groupId>
     		<artifactId>org.eclipse.emf.edit</artifactId>
     		<version>2.16.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.gemoc.commons</groupId>
-			<artifactId>org.eclipse.gemoc.commons.eclipse.pde</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.gemoc.commons</groupId>
-			<artifactId>org.eclipse.gemoc.commons.eclipse.messagingsystem.api</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.gemoc.pomfirst</groupId>
-			<artifactId>org.eclipse.gemoc.xdsmlframework.api</artifactId>
-			<version>4.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.gemoc.pomfirst</groupId>
-			<artifactId>org.eclipse.gemoc.xdsmlframework.commons</artifactId>
-			<version>4.0.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/IMEPEngine.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/IMEPEngine.java
@@ -1,0 +1,37 @@
+package org.eclipse.gemoc.executionframework.mep.engine;
+
+import org.eclipse.gemoc.executionframework.mep.events.StoppedReason;
+import org.eclipse.gemoc.executionframework.mep.launch.MEPLauncherParameters;
+import org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint;
+import org.eclipse.gemoc.executionframework.mep.types.StackFrame;
+import org.eclipse.gemoc.executionframework.mep.types.Variable;
+
+public interface IMEPEngine {
+
+	abstract void internalLaunchEngine(MEPLauncherParameters launchParameters);
+	
+	abstract StoppedReason internalNext();
+	
+	abstract StoppedReason internalStepIn();
+
+	abstract StoppedReason internalStepOut();
+	
+	abstract void internalSetBreakpoints(SourceBreakpoint[] breakpoints);
+	
+	abstract void internalTerminate();
+	
+	abstract void internalContinue();
+	
+	abstract Variable[] internalVariables();
+	
+	abstract StackFrame[] internalStackTrace();
+	
+	abstract String internalSource();
+	
+    abstract void addMEPEventListener(IMEPEventListener listener);
+
+    abstract void removeMEPEventListener(IMEPEventListener listener);
+    
+    abstract void removeAllMEPEventListeners();
+	
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/IMEPEventListener.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/IMEPEventListener.java
@@ -1,0 +1,14 @@
+package org.eclipse.gemoc.executionframework.mep.engine;
+
+import java.util.EventListener;
+
+import org.eclipse.gemoc.executionframework.mep.events.Output;
+import org.eclipse.gemoc.executionframework.mep.events.Stopped;
+
+public interface IMEPEventListener extends EventListener {
+
+	abstract void outputReceived(Output event);
+	
+	abstract void stopReceived(Stopped event);
+	
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/MEPEvent.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/engine/MEPEvent.java
@@ -1,0 +1,11 @@
+package org.eclipse.gemoc.executionframework.mep.engine;
+
+import java.util.EventObject;
+
+public class MEPEvent extends EventObject {
+
+	public MEPEvent(Object source) {
+		super(source);
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/Output.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/Output.java
@@ -1,0 +1,18 @@
+package org.eclipse.gemoc.executionframework.mep.events;
+
+import org.eclipse.gemoc.executionframework.mep.engine.MEPEvent;
+
+public class Output extends MEPEvent {
+
+	private String output;
+	
+	public Output(Object source, String output) {
+		super(source);
+		this.output = output;
+	}
+
+	public String getOutput() {
+		return output;
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/Stopped.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/Stopped.java
@@ -1,0 +1,18 @@
+package org.eclipse.gemoc.executionframework.mep.events;
+
+import org.eclipse.gemoc.executionframework.mep.engine.MEPEvent;
+
+public class Stopped extends MEPEvent {
+
+	private StoppedReason reason;
+	
+	public Stopped(Object source, StoppedReason reason) {
+		super(source);
+		this.reason = reason;
+	}
+
+	public StoppedReason getReason() {
+		return reason;
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/StoppedReason.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/events/StoppedReason.java
@@ -1,0 +1,19 @@
+package org.eclipse.gemoc.executionframework.mep.events;
+
+public enum StoppedReason {
+	REACHED_BREAKPOINT ("breakpoint"),
+	REACHED_NEXT_LOGICAL_STEP ("step"),
+	REACHED_SIMULATION_END ("end"),
+	TIME ("time");
+	
+	private final String reason;
+	
+	private StoppedReason(String reason) {
+		this.reason = reason;
+	}
+	
+	@Override
+	public String toString() {
+		return this.reason;
+	}
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
@@ -241,7 +241,10 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 						LOG.error(e.getMessage(), e);
 					}
 				}
-				
+				String languageName = "";
+				if(args.containsKey(MEPLaunchParameterKey.language.name())) {
+					languageName = (String) args.get(MEPLaunchParameterKey.language.name());
+				}				
 				String methodEntryPoint = "";
 				if(args.containsKey(MEPLaunchParameterKey.methodEntryPoint.name())) {
 					methodEntryPoint = (String) args.get(MEPLaunchParameterKey.methodEntryPoint.name());
@@ -262,6 +265,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 				
 				launcherParameters = new MEPLauncherParameters();
 				launcherParameters.resourceModel = res;
+				launcherParameters.languageName = languageName;
 				launcherParameters.modelEntryPoint = modelEntryPoint; 
 				launcherParameters.methodEntryPoint = methodEntryPoint;
 				launcherParameters.initializationMethod = initializationMethod;

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/GemocMEPServerImpl.java
@@ -14,6 +14,11 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.gemoc.executionframework.mep.engine.IMEPEngine;
+import org.eclipse.gemoc.executionframework.mep.engine.IMEPEventListener;
+import org.eclipse.gemoc.executionframework.mep.events.Output;
+import org.eclipse.gemoc.executionframework.mep.events.Stopped;
+import org.eclipse.gemoc.executionframework.mep.events.StoppedReason;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
 import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolServer;
 import org.eclipse.gemoc.executionframework.mep.services.ModelExecutionClientAware;
@@ -35,7 +40,9 @@ import org.eclipse.lsp4j.debug.StackTraceArguments;
 import org.eclipse.lsp4j.debug.StackTraceResponse;
 import org.eclipse.lsp4j.debug.StepInArguments;
 import org.eclipse.lsp4j.debug.StepOutArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.TerminateArguments;
+import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.Variable;
 import org.eclipse.lsp4j.debug.VariablesArguments;
 import org.eclipse.lsp4j.debug.VariablesResponse;
@@ -46,7 +53,7 @@ import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 
-abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServer, Endpoint, JsonRpcMethodProvider, ModelExecutionClientAware {
+abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServer, Endpoint, JsonRpcMethodProvider, ModelExecutionClientAware, IMEPEventListener {
 
 	private static final Logger LOG = Logger.getLogger(GemocMEPServerImpl.class);
 
@@ -54,12 +61,19 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 	
 	//private final Multimap<String, Endpoint> extensionProviders = LinkedListMultimap.create();
 	
+	protected IMEPEngine mepEngine;
+	
 	protected IModelExecutionProtocolClient client;
 	
 	protected boolean initialized = false;
 	protected boolean simulationStarted = false;
 	protected MEPLauncherParameters launcherParameters = null;
 	protected Breakpoint[] breakpoints = new Breakpoint[0];
+	
+	public GemocMEPServerImpl(IMEPEngine mepEngine) {
+		this.mepEngine = mepEngine;
+		this.mepEngine.addMEPEventListener(this);
+	}
 	
 	@Override
 	public Map<String, JsonRpcMethod> supportedMethods() {
@@ -272,7 +286,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				
-				internalContinue();
+				mepEngine.internalContinue();
 				
 				ContinueResponse response = new ContinueResponse();
 				return response;
@@ -292,7 +306,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				
-				internalNext();
+				mepEngine.internalNext();
 			}
 		});
 		return future;
@@ -309,10 +323,36 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				
-				internalStepIn();
+				mepEngine.internalStepIn();
 			}
 		});
 		return future;
+	}
+	
+	protected void manageStop(StoppedReason stopReason) {
+		switch (stopReason) {
+			case REACHED_BREAKPOINT:
+				StoppedEventArguments stoppedArgsBreakpoint = new StoppedEventArguments();
+				stoppedArgsBreakpoint.setReason(stopReason.toString());
+				stoppedArgsBreakpoint.setDescription("Reached breakpoint");
+				client.stopped(stoppedArgsBreakpoint);
+				break;
+			case REACHED_NEXT_LOGICAL_STEP:
+				StoppedEventArguments stoppedArgsStep = new StoppedEventArguments();
+				stoppedArgsStep.setReason(stopReason.toString());
+				stoppedArgsStep.setDescription("Reached new logical step");
+				client.stopped(stoppedArgsStep);
+				break;
+			case REACHED_SIMULATION_END:
+				TerminatedEventArguments terminatedArgs = new TerminatedEventArguments();
+				client.terminated(terminatedArgs);
+				simulationStarted = false;
+				break;
+			case TIME:
+				break;
+			default:
+				break;
+		}
 	}
 	
 	@Override
@@ -326,7 +366,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				
-				internalStepOut();
+				mepEngine.internalStepOut();
 			}
 		});
 		return future;
@@ -339,17 +379,21 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 		    public SetBreakpointsResponse get() {
 				//TODO: Manage different sources for breakpoints
 				SetBreakpointsResponse response = new SetBreakpointsResponse();
-	
-				internalClearBreakpoints();
-				
+					
 				List<Breakpoint> bps = new ArrayList<>();
+				org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint[] mepBreakpoints =
+						new org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint[args.getBreakpoints().length];
+				int i = 0;
 				for (SourceBreakpoint sbp : args.getBreakpoints()) {
+					org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint mepBreakpoint =
+							new org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint(sbp.getLine());
+					mepBreakpoints[i++] = mepBreakpoint;
 					Breakpoint bp = new Breakpoint();
 					bp.setVerified(true);
 					bp.setLine(sbp.getLine());
-					internalToggleBreakpoint(sbp.getLine().intValue());
 					bps.add(bp);
 				}
+				mepEngine.internalSetBreakpoints(mepBreakpoints);
 				breakpoints = bps.toArray(new Breakpoint[0]);
 				response.setBreakpoints(breakpoints);
 				
@@ -370,14 +414,18 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				if (simulationStarted) {
-					internalTerminate();
+					mepEngine.internalTerminate();
 					simulationStarted = false;
 				}
 				launchGemocEngine(launcherParameters);
 				simulationStarted = true;
+				org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint mepBreakpoints[] =
+						new org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint[breakpoints.length];
+				int i = 0;
 				for (Breakpoint bp : breakpoints) {
-					internalToggleBreakpoint(bp.getLine().intValue());
+					mepBreakpoints[i++] = new org.eclipse.gemoc.executionframework.mep.types.SourceBreakpoint(bp.getLine().intValue());
 				}
+				mepEngine.internalSetBreakpoints(mepBreakpoints);
 			}
 		});
 		return future;
@@ -394,7 +442,18 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				StackTraceResponse response = new StackTraceResponse();
-				response.setStackFrames(internalStackTrace());
+				org.eclipse.gemoc.executionframework.mep.types.StackFrame[] mepFrames = mepEngine.internalStackTrace();
+				StackFrame[] dapFrames = new StackFrame[mepFrames.length];
+				int i = 0;
+				for (org.eclipse.gemoc.executionframework.mep.types.StackFrame mepFrame : mepFrames) {
+					StackFrame dapFrame = new StackFrame();
+					dapFrame.setId(mepFrame.getId());
+					dapFrame.setName(mepFrame.getName());
+					dapFrame.setLine(mepFrame.getLine());
+					dapFrame.setColumn(mepFrame.getColumn());
+					dapFrames[i++] = dapFrame;
+				}
+				response.setStackFrames(dapFrames);
 				return response;
 			}
 		});
@@ -412,7 +471,16 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				VariablesResponse response = new VariablesResponse();
-				response.setVariables(internalVariables());
+				org.eclipse.gemoc.executionframework.mep.types.Variable[] mepVariables = mepEngine.internalVariables();
+				Variable[] dapVariables = new Variable[mepVariables.length];
+				int i = 0;
+				for (org.eclipse.gemoc.executionframework.mep.types.Variable mepVariable : mepVariables) {
+					Variable dapVariable = new Variable();
+					dapVariable.setName(mepVariable.getName());
+					dapVariable.setValue(mepVariable.getValue());
+					dapVariables[i++] = dapVariable;
+				}
+				response.setVariables(dapVariables);
 				return response;
 			}
 		});
@@ -430,18 +498,12 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					throw new ResponseErrorException(error);
 				}
 				SourceResponse response = new SourceResponse();
-				response.setContent(internalSource());
+				response.setContent(mepEngine.internalSource());
 				return response;
 			}
 		});
 		return future;
 	}
-
-	protected abstract void internalNext();
-	
-	protected abstract void internalStepIn();
-
-	protected abstract void internalStepOut();
 
 	@Override
 	public CompletableFuture<Void> terminate(TerminateArguments args) {
@@ -453,7 +515,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 					error.setMessage("Simulation not started");
 					throw new ResponseErrorException(error);
 				}
-				internalTerminate();
+				mepEngine.internalTerminate();
 				simulationStarted = false;
 			}
 		});
@@ -467,20 +529,6 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 		client.output(args);
 	}
 	
-	protected abstract void internalClearBreakpoints();
-	
-	protected abstract void internalToggleBreakpoint(int line);
-	
-	protected abstract void internalTerminate();
-	
-	protected abstract void internalContinue();
-	
-	protected abstract Variable[] internalVariables();
-	
-	protected abstract StackFrame[] internalStackTrace();
-	
-	protected abstract String internalSource();
-	
 	/**
 	 * create a resource set
 	 * by default it only allows to load xmi models
@@ -492,19 +540,17 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 	}
 
 	public void launchGemocEngine(MEPLauncherParameters parameters) {
-		launchGemocEngine(parameters.resourceModel, parameters.modelEntryPoint, parameters.methodEntryPoint,
-				parameters.initializationMethod, parameters.initializationMethodArgs);
+		mepEngine.internalLaunchEngine(parameters);
 	}
 	
-	/**
-	 * 
-	 * @param resourceModel
-	 * @param selectedLanguage
-	 * @param modelEntryPoint
-	 * @param methodEntryPoint
-	 * @param initializationMethod
-	 * @param initializationMethodArgs
-	 */
-	abstract public void launchGemocEngine(Resource resourceModel, String modelEntryPoint,
-			String methodEntryPoint, String initializationMethod, String initializationMethodArgs);
+	@Override
+	public void outputReceived(Output event) {
+		this.sendOutput(event.getOutput());
+	}
+	
+	@Override
+	public void stopReceived(Stopped event) {
+		this.manageStop(event.getReason());
+	}
+	
 }

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncher.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncher.java
@@ -8,13 +8,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolClient;
-import org.eclipse.gemoc.executionframework.mep.services.IModelExecutionProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint;
-import org.eclipse.lsp4j.jsonrpc.debug.DebugRemoteEndpoint;
 import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncherParameters.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPLauncherParameters.java
@@ -4,6 +4,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 
 public class MEPLauncherParameters {
 	
+	public String languageName = "";
 	public Resource resourceModel = null;
 	public String modelEntryPoint = "";
 	public String methodEntryPoint = "";

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPServerLSP4J.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/launch/MEPServerLSP4J.java
@@ -53,9 +53,9 @@ import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 
-abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServer, Endpoint, JsonRpcMethodProvider, ModelExecutionClientAware, IMEPEventListener {
+abstract public class MEPServerLSP4J implements IModelExecutionProtocolServer, Endpoint, JsonRpcMethodProvider, ModelExecutionClientAware, IMEPEventListener {
 
-	private static final Logger LOG = Logger.getLogger(GemocMEPServerImpl.class);
+	private static final Logger LOG = Logger.getLogger(MEPServerLSP4J.class);
 
 	private Map<String, JsonRpcMethod> supportedMethods;
 	
@@ -70,7 +70,7 @@ abstract public class GemocMEPServerImpl implements IModelExecutionProtocolServe
 	protected MEPLauncherParameters launcherParameters = null;
 	protected Breakpoint[] breakpoints = new Breakpoint[0];
 	
-	public GemocMEPServerImpl(IMEPEngine mepEngine) {
+	public MEPServerLSP4J(IMEPEngine mepEngine) {
 		this.mepEngine = mepEngine;
 		this.mepEngine.addMEPEventListener(this);
 	}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/SourceBreakpoint.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/SourceBreakpoint.java
@@ -1,0 +1,15 @@
+package org.eclipse.gemoc.executionframework.mep.types;
+
+public class SourceBreakpoint {
+	
+	private long line;
+	
+	public SourceBreakpoint(long line) {
+		this.line = line;
+	}
+	
+	public long getLine() {
+		return this.line;
+	}
+
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/StackFrame.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/StackFrame.java
@@ -1,0 +1,33 @@
+package org.eclipse.gemoc.executionframework.mep.types;
+
+public class StackFrame {
+
+	private long id;
+	private String name;
+	private long line;
+	private long column;
+	
+	public StackFrame(long id, String name, long line, long column) {
+		this.id = id;
+		this.name = name;
+		this.line = line;
+		this.column = column;
+	}
+	
+	public long getId() {
+		return id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public long getLine() {
+		return line;
+	}
+	
+	public long getColumn() {
+		return column;
+	}
+	
+}

--- a/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/Variable.java
+++ b/framework/execution_framework/pomfirst/org.eclipse.gemoc.executionframework.mep/src/main/java/org/eclipse/gemoc/executionframework/mep/types/Variable.java
@@ -1,0 +1,22 @@
+package org.eclipse.gemoc.executionframework.mep.types;
+
+public class Variable {
+
+	private String name;
+	private String value;
+	
+	
+	public Variable(String name, String value) {
+		this.name = name;
+		this.value = value;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public String getValue() {
+		return value;
+	}
+
+}

--- a/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/AddDebugRepresentationPage.java
+++ b/framework/xdsml_framework/plugins/org.eclipse.gemoc.xdsmlframework.extensions.sirius/src/main/java/org/eclipse/gemoc/xdsmlframework/extensions/sirius/wizards/pages/AddDebugRepresentationPage.java
@@ -11,6 +11,7 @@
 package org.eclipse.gemoc.xdsmlframework.extensions.sirius.wizards.pages;
 
 import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.sirius.diagram.business.internal.metamodel.helper.LayerHelper;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.Layer;
 import org.eclipse.swt.SWT;
@@ -77,7 +78,7 @@ public class AddDebugRepresentationPage extends WizardPage {
 
 	public void setDiagram(DiagramDescription diagram) {
 		debugLayerCombo.removeAll();
-		for (Layer layer : diagram.getAllLayers()) {
+		for (Layer layer : LayerHelper.getAllLayers(diagram)) {
 			debugLayerCombo.add(layer.getName());
 		}
 		debugLayerCombo.setText("Debug");


### PR DESCRIPTION
This PR aims to better define a MEP Engine in the context of GEMOC, and to properly separate existing engines and their support of the protocol.

The envisioned architecture is the following:
![Architecture MEP Java](https://user-images.githubusercontent.com/7363343/84521132-df712580-acd4-11ea-867f-4cf48da740c0.png)

Basically, existing engines should not be modified to support MEP, and support should be added as extensions.
The fact that we currently rely on a LSP4J server should not have any impact on the rest, and thus all dependencies to LSP4J were isolated.

