### PR TITLE
Improved description of the sirius java service for debug

### DIFF
--- a/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/docs/asciidoc/user_lw_DefineSiriusDebug.asciidoc
+++ b/simulationmodelanimation/plugins/org.eclipse.gemoc.dsl.debug.ide.sirius.ui/docs/asciidoc/user_lw_DefineSiriusDebug.asciidoc
@@ -76,6 +76,25 @@ The debugger services class is use to tell which representations should be activ
 
 image::images/workbench/language/debug_services.png[Debug services]
 
+
+[IMPORTANT]
+====
+
+The line `res.add(new StringCouple("DD_or_RN", "LAYER_ID"));` indicates
+which layers are part of the "debug" animation. Ie. if these layers must be activated automatically
+and updated when an execution is in debug mode.
+
+The way to indicate the layer depends on how you have created the layer:
+
+*  in case of a single odesign with all layers in a single viewpoint:
+** the first String _DD_or_RN_ is the _id_ of the Diagram Description
+** the second String _LAYER_ID_ is the _id_ of the Layer
+*	in case of a diagram extension:
+** the first String _DD_or_RN_ is the _Representation Name_ of the Diagram Extension (do not confuse with the Name !!)
+** the second String _LAYER_ID_ is the _id_ of the Layer
+
+====
+
 ====== Debug layer
 The default debug layer adds action to start the simulation in debug mode and to toggle breakpoints (1). When a breakpoint exists for an element of the diagram, a visual feedback is displayed according to the breakpoint state (2). The current instruction is also highlighted in yellow by default (3).
 


### PR DESCRIPTION



## Description
This Pull request improves the text explaining the java class AbstractGemocDebuggerServices and the expected content of the method 

```java
protected List<StringCouple> getRepresentationRefreshList() {
		final List<StringCouple> res = new ArrayList<StringCouple>();
```



## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio/pull/217
