### PR TITLE
[Event Manager PR#1] Support for execution step parameters + misc.

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
@@ -13,6 +13,7 @@
 import org.eclipse.emf.transaction.RecordingCommand
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext
+import java.util.Arrays
 
 abstract class AbstractCommandBasedSequentialExecutionEngine<C extends IExecutionContext<R, ?, ?>, R extends IRunConfiguration> extends AbstractSequentialExecutionEngine<C, R> {
 
@@ -25,13 +26,17 @@ abstract class AbstractCommandBasedSequentialExecutionEngine<C extends IExecutio
 	 * @param operation
 	 */
 	protected def void executeOperation(Object caller, String className, String operationName, Runnable operation) {
+		executeOperation(caller, #{}, className, operationName, operation);
+	}
+	
+	protected def void executeOperation(Object caller, Object[] parameters, String className, String operationName, Runnable operation) {
 		val RecordingCommand rc = new RecordingCommand(editingDomain) {
 			override doExecute() {
 				operation.run()
 			}
 		}
 		try {
-			beforeExecutionStep(caller, className, operationName, rc)
+			beforeExecutionStep(caller, className, operationName, rc, Arrays.asList(parameters))
 			rc.execute
 			afterExecutionStep
 		} finally {

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/GemocRunningEnginesRegistry.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/GemocRunningEnginesRegistry.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.gemoc.executionframework.engine.core;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,82 +25,90 @@ public class GemocRunningEnginesRegistry {
 	
 	
 	/**
-	 * Add the given engine with this name
-	 * @param baseName (not used !? should be removed from API)
+	 * Add the given engine under the provided name
+	 * 
+	 * @param baseName
 	 * @param engine to add
 	 * @return the unique name really used for this engine
 	 */
 	 public synchronized String registerEngine(String baseName, IExecutionEngine<?> engine){
 		int uniqueInstance = 0;
-		String engineName = Thread.currentThread().getName() + " ("+uniqueInstance+")";
-		synchronized(runningEngines)
-		{
-			while(runningEngines.containsKey(engineName)){
-				uniqueInstance = uniqueInstance +1;
-				engineName = Thread.currentThread().getName() + " ("+uniqueInstance+")";
+		String engineName = baseName;
+		synchronized (runningEngines) {
+			while (runningEngines.containsKey(engineName)) {
+				uniqueInstance = uniqueInstance + 1;
+				engineName = baseName + " (" + uniqueInstance + ")";
 			}
 			runningEngines.put(engineName, engine);
 		}
-		notifyEngineRegistered(engine);			
+		notifyEngineRegistered(engine);
 		return engineName;
 	}
 
-	public void unregisterEngine(String engineName) 
-	{
-		synchronized(runningEngines)
-		{
+	/**
+	 * Add the given engine under a generated name
+	 * 
+	 * @param engine to add
+	 * @return the unique name really used for this engine
+	 */
+	public synchronized String registerEngine(IExecutionEngine<?> engine) {
+		int uniqueInstance = 0;
+		String engineName = Thread.currentThread().getName();
+		synchronized (runningEngines) {
+			while (runningEngines.containsKey(engineName)) {
+				uniqueInstance = uniqueInstance + 1;
+				engineName = Thread.currentThread().getName() + " (" + uniqueInstance + ")";
+			}
+			runningEngines.put(engineName, engine);
+		}
+		notifyEngineRegistered(engine);
+		return engineName;
+	}
+
+	public void unregisterEngine(String engineName) {
+		synchronized (runningEngines) {
 			IExecutionEngine<?> engine = runningEngines.get(engineName);
-			if (engine != null)
-			{
+			if (engine != null) {
 				runningEngines.remove(engineName);
 				notifyEngineUnregistered(engine);
-			}			
+			}
 		}
 	}
 
 	public HashMap<String, IExecutionEngine<?>> getRunningEngines() {
-		synchronized(runningEngines)
-		{
-			return new HashMap<String, IExecutionEngine<?>>(runningEngines);			
+		synchronized (runningEngines) {
+			return new HashMap<String, IExecutionEngine<?>>(runningEngines);
 		}
 	}
-	
-	
+
 	private List<IEngineRegistrationListener> _engineRegistrationListeners = new ArrayList<IEngineRegistrationListener>();
 	
 	private void notifyEngineRegistered(IExecutionEngine<?> engine) {
 		synchronized (_engineRegistrationListeners) {
-			for (IEngineRegistrationListener l : _engineRegistrationListeners)
-			{
+			for (IEngineRegistrationListener l : _engineRegistrationListeners) {
 				l.engineRegistered(engine);
-			}			
+			}
 		}
 	}
 	
 	private void notifyEngineUnregistered(IExecutionEngine<?> engine) {
 		synchronized (_engineRegistrationListeners) {
-			for (IEngineRegistrationListener l : _engineRegistrationListeners)
-			{
+			for (IEngineRegistrationListener l : _engineRegistrationListeners) {
 				l.engineUnregistered(engine);
-			}			
+			}
 		}
 	}
 
-
-	public void addEngineRegistrationListener(IEngineRegistrationListener listener) 
-	{
+	public void addEngineRegistrationListener(IEngineRegistrationListener listener) {
 		synchronized (_engineRegistrationListeners) {
 			_engineRegistrationListeners.add(listener);
 		}
 	}
 
-	public void removeEngineRegistrationListener(IEngineRegistrationListener listener) 
-	{
+	public void removeEngineRegistrationListener(IEngineRegistrationListener listener) {
 		synchronized (_engineRegistrationListeners) {
 			_engineRegistrationListeners.remove(listener);
 		}
 	}
-
-
 
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/RunConfiguration.java
@@ -13,7 +13,9 @@ package org.eclipse.gemoc.executionframework.engine.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -65,6 +67,7 @@ public class RunConfiguration implements IRunConfiguration {
 		_debugModelID = getAttribute(DEBUG_MODEL_ID, ".debugModel");
 	}
 
+	@Override
 	public String getAttribute(String attributeName, String defaultValue) {
 		try {
 			return _launchConfiguration.getAttribute(attributeName, defaultValue);
@@ -74,6 +77,7 @@ public class RunConfiguration implements IRunConfiguration {
 		}
 	}
 
+	@Override
 	public Integer getAttribute(String attributeName, Integer defaultValue) {
 		try {
 			return _launchConfiguration.getAttribute(attributeName, defaultValue);
@@ -83,7 +87,28 @@ public class RunConfiguration implements IRunConfiguration {
 		}
 	}
 
+	@Override
 	public Boolean getAttribute(String attributeName, Boolean defaultValue) {
+		try {
+			return _launchConfiguration.getAttribute(attributeName, defaultValue);
+		} catch (CoreException e) {
+			Activator.getDefault().error(e.getMessage(), e);
+			return defaultValue;
+		}
+	}
+
+	@Override
+	public Map<String, String> getAttribute(String attributeName, Map<String, String> defaultValue) {
+		try {
+			return _launchConfiguration.getAttribute(attributeName, defaultValue);
+		} catch (CoreException e) {
+			Activator.getDefault().error(e.getMessage(), e);
+			return defaultValue;
+		}
+	}
+
+	@Override
+	public Set<String> getAttribute(String attributeName, Set<String> defaultValue) {
 		try {
 			return _launchConfiguration.getAttribute(attributeName, defaultValue);
 		} catch (CoreException e) {

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/Activator.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/Activator.java
@@ -21,7 +21,6 @@ import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystemMana
 import org.eclipse.gemoc.executionframework.ui.views.engine.EngineSelectionManager;
 import org.osgi.framework.BundleContext;
 
-
 /**
  * The activator class controls the plug-in life cycle
  *
@@ -33,11 +32,9 @@ public class Activator extends AbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.gemoc.gemoc_language_workbench.ui"; //$NON-NLS-1$
 
 	public static final String GEMOC_PROJECT_CONFIGURATION_FILE_EXTENSION = "xdsml";
-	public static final String GEMOC_PROJECT_CONFIGURATION_FILE = "project."
-			+ GEMOC_PROJECT_CONFIGURATION_FILE_EXTENSION;
+	public static final String GEMOC_PROJECT_CONFIGURATION_FILE = "project." + GEMOC_PROJECT_CONFIGURATION_FILE_EXTENSION;
 
 	// extension point constants
-	
 
 	public static final String MODEL_LOADER_CLASS_NAMEPART = "ModelLoader";
 	public static final String CODEEXECUTOR_CLASS_NAMEPART = "CodeExecutor";
@@ -48,12 +45,9 @@ public class Activator extends AbstractUIPlugin {
 	private static Activator plugin;
 
 	private final EngineSelectionManager engineSelectionManager = new EngineSelectionManager();
-	
-
-
 
 	private final List<IMSEPresenter> eventPresenters = new ArrayList<>();
-	
+
 	/**
 	 * The constructor
 	 */
@@ -80,8 +74,11 @@ public class Activator extends AbstractUIPlugin {
 	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext
 	 * )
 	 */
-	/* (non-Javadoc)
-	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
 	 */
 	@Override
 	public void stop(BundleContext context) throws Exception {
@@ -99,11 +96,11 @@ public class Activator extends AbstractUIPlugin {
 	}
 
 	/**
-	 * Returns an image descriptor for the image file at the given plug-in
-	 * relative path
+	 * Returns an image descriptor for the image file at the given plug-in relative
+	 * path
 	 * 
 	 * @param path
-	 *            the path
+	 *                 the path
 	 * @return the image descriptor
 	 */
 	public static ImageDescriptor getImageDescriptor(String path) {
@@ -118,8 +115,6 @@ public class Activator extends AbstractUIPlugin {
 		Activator.getDefault().getLog().log(new Status(Status.ERROR, PLUGIN_ID, Status.OK, msg, e));
 	}
 
-
-	
 	/**
 	 * Gets the {@link List} of registered {@link IMSEPresenter}s.
 	 * 
@@ -128,20 +123,17 @@ public class Activator extends AbstractUIPlugin {
 	public List<IMSEPresenter> getEventPresenters() {
 		return eventPresenters;
 	}
-	
 
 	public EngineSelectionManager getEngineSelectionManager() {
 		return engineSelectionManager;
 	}
-	
+
 	protected MessagingSystem messaggingSystem = null;
-	
+
 	public MessagingSystem getMessaggingSystem() {
 		if (messaggingSystem == null) {
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messaggingSystem = msm.createBestPlatformMessagingSystem(
-					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID,
-					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
+			messaggingSystem = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messaggingSystem;
 	}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/IMSEPresenter.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/IMSEPresenter.java
@@ -15,9 +15,9 @@ import java.util.List;
 import org.eclipse.emf.common.util.URI;
 
 /**
- * a class that implements IMSEPresenter is a graphical UI that 
- * presents or displays ModelSpecificEvents
- * When asked it should highlight or focus on the requested  ModelSpecificEvents
+ * a class that implements IMSEPresenter is a graphical UI that presents or
+ * displays ModelSpecificEvents When asked it should highlight or focus on the
+ * requested ModelSpecificEvents
  * 
  * @author <a href="mailto:yvan.lussaud@obeo.fr">Yvan Lussaud</a>
  *
@@ -25,9 +25,11 @@ import org.eclipse.emf.common.util.URI;
 public interface IMSEPresenter {
 
 	/**
-	 * Ask the view to present or highlight the given {@link List} of ModelSpecificEvent
+	 * Ask the view to present or highlight the given {@link List} of
+	 * ModelSpecificEvent
 	 * 
-	 * @param events ModelSpecificEvent to highlight
+	 * @param events
+	 *                   ModelSpecificEvent to highlight
 	 */
 	void present(List<URI> events);
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/SharedIcons.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/SharedIcons.java
@@ -21,15 +21,15 @@ public class SharedIcons {
 	public static ImageDescriptor RUNNING_ENGINE_ICON = ImageDescriptor.createFromFile(SharedIcons.class, "/icons/services-16-green.png");
 	public static ImageDescriptor STOPPED_ENGINE_ICON = ImageDescriptor.createFromFile(SharedIcons.class, "/icons/services-16-red.png");
 	public static ImageDescriptor WAITING_ENGINE_ICON = ImageDescriptor.createFromFile(SharedIcons.class, "/icons/services-16-blue.png");
-	
+
 	public static ImageDescriptor RESUME_ENGINE_DECIDER_ICON = ImageDescriptor.createFromFile(SharedIcons.class, "/icons/resume_co.png");
 	public static ImageDescriptor SUSPEND_ENGINE_DECIDER_ICON = ImageDescriptor.createFromFile(SharedIcons.class, "/icons/suspend_co.png");
-	
+
 	static HashMap<ImageDescriptor, Image> imageMap = new HashMap<ImageDescriptor, Image>();
-	
-	static public Image getSharedImage(ImageDescriptor descriptor){
+
+	static public Image getSharedImage(ImageDescriptor descriptor) {
 		Image res = imageMap.get(descriptor);
-		if(res == null){
+		if (res == null) {
 			res = descriptor.createImage();
 			imageMap.put(descriptor, res);
 		}

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/utils/ENamedElementQualifiedNameLabelProvider.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/utils/ENamedElementQualifiedNameLabelProvider.java
@@ -17,17 +17,16 @@ public class ENamedElementQualifiedNameLabelProvider extends LabelProvider {
 
 	@Override
 	public String getText(Object element) {
-		if(element instanceof ENamedElement){
+		if (element instanceof ENamedElement) {
 			StringBuilder sb = new StringBuilder();
-			if(((ENamedElement)element).eContainer() != null){
-				sb.append(getText(((ENamedElement)element).eContainer()));
+			if (((ENamedElement) element).eContainer() != null) {
+				sb.append(getText(((ENamedElement) element).eContainer()));
 				sb.append("::");
 			}
-			sb.append(((ENamedElement)element).getName());
+			sb.append(((ENamedElement) element).getName());
 			return sb.toString();
-		}
-		else return super.getText(element);
+		} else
+			return super.getText(element);
 	}
-	
 
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/utils/ViewUtils.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/utils/ViewUtils.java
@@ -18,20 +18,18 @@ public class ViewUtils {
 
 	public static String eventToString(MSE mse) {
 		StringBuilder builder = new StringBuilder();
-		if (mse.getCaller() != null)
-		{
+		if (mse.getCaller() != null) {
 			builder.append(mse.getCaller().eClass().getName());
 			builder.append("->");
 			builder.append(SimpleAttributeResolver.NAME_RESOLVER.apply(mse.getCaller()));
-			
+
 		}
-		if (mse.getAction() != null)
-		{
+		if (mse.getAction() != null) {
 			builder.append(".");
-			builder.append(mse.getAction().getName());			
+			builder.append(mse.getAction().getName());
 			builder.append("()");
 		}
 		return builder.toString();
 	}
-	
+
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionDependentViewPart.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionDependentViewPart.java
@@ -17,29 +17,26 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ViewPart;
 
 /**
- * Views that are dependent on the engine selection in the EnginesStatusView may subclass this to get registered to it
+ * Views that are dependent on the engine selection in the EnginesStatusView may
+ * subclass this to get registered to it
  *
  */
-public abstract class EngineSelectionDependentViewPart extends ViewPart implements
-		IEngineSelectionListener {
+public abstract class EngineSelectionDependentViewPart extends ViewPart implements IEngineSelectionListener {
 
-	
-	public EngineSelectionDependentViewPart()
-	{
+	public EngineSelectionDependentViewPart() {
 	}
-	
+
 	@Override
 	public void init(IViewSite site) throws PartInitException {
 		super.init(site);
 		startListeningToEngineSelectionChange();
 	}
-	
+
 	@Override
 	public void dispose() {
 		super.dispose();
 		stopListeningToEngineSelectionChange();
 	}
-
 
 	protected void startListeningToEngineSelectionChange() {
 		// make sure the EngineStatusView is open
@@ -51,6 +48,5 @@ public abstract class EngineSelectionDependentViewPart extends ViewPart implemen
 	protected void stopListeningToEngineSelectionChange() {
 		Activator.getDefault().getEngineSelectionManager().removeEngineSelectionListener(this);
 	}
-
 
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionManager.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EngineSelectionManager.java
@@ -16,27 +16,29 @@ import java.util.List;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 
 /**
- * This class is in charge of knowing what was the last selected engine and keeping the list of all EngineSelectionListener
+ * This class is in charge of knowing what was the last selected engine and
+ * keeping the list of all EngineSelectionListener
  *
  */
-public class EngineSelectionManager implements IEngineSelectionListener{
+public class EngineSelectionManager implements IEngineSelectionListener {
 
-	private IExecutionEngine _lastSelectedEngine;
+	private IExecutionEngine<?> _lastSelectedEngine;
 	private final List<IEngineSelectionListener> engineSelectionListeners;
-	
-	public EngineSelectionManager(){
+
+	public EngineSelectionManager() {
 		engineSelectionListeners = new ArrayList<>();
-		// register self as IEngineSelectionListener in order to know the last selected engine even if no EngineStatusView is opened
+		// register self as IEngineSelectionListener in order to know the last selected
+		// engine even if no EngineStatusView is opened
 		engineSelectionListeners.add(this);
 	}
-	
-	public IExecutionEngine get_lastSelectedEngine() {
+
+	public IExecutionEngine<?> get_lastSelectedEngine() {
 		return _lastSelectedEngine;
 	}
 
 	@Override
-	public void engineSelectionChanged(IExecutionEngine engine) {
-		_lastSelectedEngine = engine;		
+	public void engineSelectionChanged(IExecutionEngine<?> engine) {
+		_lastSelectedEngine = engine;
 	}
 
 	/**
@@ -47,13 +49,15 @@ public class EngineSelectionManager implements IEngineSelectionListener{
 	public List<IEngineSelectionListener> getEngineSelectionListeners() {
 		return engineSelectionListeners;
 	}
+
 	public void addEngineSelectionListener(IEngineSelectionListener listener) {
-		assert(listener != null);
+		assert (listener != null);
 		engineSelectionListeners.add(listener);
 	}
+
 	public void removeEngineSelectionListener(IEngineSelectionListener listener) {
-		assert(listener != null);
+		assert (listener != null);
 		engineSelectionListeners.remove(listener);
 	}
-	
+
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/EnginesStatusView.java
@@ -342,7 +342,7 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 	public void engineRegistered(final IExecutionEngine<?> engine) {
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				Activator.getDefault().getMessaggingSystem().debug("Enabled implicit addon: "+EnginesStatusView.this.getAddonID(), Activator.PLUGIN_ID);
+				Activator.getDefault().getMessaggingSystem().debug("Enabled implicit addon: " + EnginesStatusView.this.getAddonID(), Activator.PLUGIN_ID);
 				engine.getExecutionContext().getExecutionPlatform().addEngineAddon(EnginesStatusView.this);
 				_viewer.setInput(org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry);
 				TreeViewerHelper.resizeColumns(_viewer);
@@ -420,12 +420,8 @@ public class EnginesStatusView extends ViewPart implements IEngineAddon, IEngine
 		// the debugger addon will stop the execution in this event
 		// make sure to be called before in order to properly refresh the view
 		ArrayList<EngineAddonSortingRule> sortingRules = new ArrayList<EngineAddonSortingRule>();
-		sortingRules.add(new EngineAddonSortingRule( this,
-				EngineAddonSortingRule.EngineEvent.aboutToExecuteStep,
-				EngineAddonSortingRule.Priority.BEFORE,
-				Arrays.asList(IGemocDebugger.GROUP_TAG)));
+		sortingRules.add(new EngineAddonSortingRule(this, EngineAddonSortingRule.EngineEvent.aboutToExecuteStep, EngineAddonSortingRule.Priority.BEFORE, Arrays.asList(IGemocDebugger.GROUP_TAG)));
 		return sortingRules;
 	}
-	
-	
+
 }

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/ViewContentProvider.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.ui/src/org/eclipse/gemoc/executionframework/ui/views/engine/ViewContentProvider.java
@@ -20,59 +20,50 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.gemoc.executionframework.engine.core.GemocRunningEnginesRegistry;
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine;
 
-class ViewContentProvider implements ITreeContentProvider 
-{
+class ViewContentProvider implements ITreeContentProvider {
 
 	public void inputChanged(Viewer v, Object oldInput, Object newInput) {
 	}
 
 	public void dispose() {
 	}
-	
+
 	public Object[] getElements(Object parent) {
-		if (parent instanceof GemocRunningEnginesRegistry)
-		{
+		if (parent instanceof GemocRunningEnginesRegistry) {
 			GemocRunningEnginesRegistry registry = org.eclipse.gemoc.executionframework.engine.Activator.getDefault().gemocRunningEngineRegistry;
-			List<IExecutionEngine> engines = new ArrayList<IExecutionEngine>(registry.getRunningEngines().values());
-			Collections.sort(engines, getComparator()); 
+			List<IExecutionEngine<?>> engines = new ArrayList<IExecutionEngine<?>>(registry.getRunningEngines().values());
+			Collections.sort(engines, getComparator());
 			return engines.toArray();
 		}
 		return null;
 	}
-	public Object getParent(Object child) 
-	{
+
+	public Object getParent(Object child) {
 		return null;
 	}
-	
-	public Object [] getChildren(Object parent) 
-	{
+
+	public Object[] getChildren(Object parent) {
 		return new Object[0];
 	}
-	
-	public boolean hasChildren(Object parent) 
-	{
+
+	public boolean hasChildren(Object parent) {
 		return false;
 	}
-	
-	private Comparator<IExecutionEngine> getComparator()
-	{
-		Comparator<IExecutionEngine> comparator = new Comparator<IExecutionEngine>() {
-		    public int compare(IExecutionEngine c1, IExecutionEngine c2) 
-		    {
-		    	int c1Value = c1.getRunningStatus().ordinal();
-		    	int c2Value = c2.getRunningStatus().ordinal();
-		        if (c1Value < c2Value) 
-		        {
-		        	return -1;
-		        } 
-		        else if (c1Value > c2Value) 
-		        {
-		        	return 1;
-		        }  
-		        return 0;
-		    }
+
+	private Comparator<IExecutionEngine<?>> getComparator() {
+		Comparator<IExecutionEngine<?>> comparator = new Comparator<IExecutionEngine<?>>() {
+			public int compare(IExecutionEngine<?> c1, IExecutionEngine<?> c2) {
+				int c1Value = c1.getRunningStatus().ordinal();
+				int c2Value = c2.getRunningStatus().ordinal();
+				if (c1Value < c2Value) {
+					return -1;
+				} else if (c1Value > c2Value) {
+					return 1;
+				}
+				return 0;
+			}
 		};
 		return comparator;
 	}
-	
+
 }

--- a/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
+++ b/framework/framework_commons/plugins/org.eclipse.gemoc.xdsmlframework.api/src/org/eclipse/gemoc/xdsmlframework/api/core/IRunConfiguration.java
@@ -11,6 +11,8 @@
 package org.eclipse.gemoc.xdsmlframework.api.core;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.engine_addon.EngineAddonSpecificationExtension;
@@ -69,6 +71,26 @@ public interface IRunConfiguration {
 	 * @return
 	 */	
 	Boolean getAttribute(String attributeName, Boolean defaultValue);
+
+	/**
+	 * return a map attribute from the runconfiguration identified by attributeName
+	 * returns the default value if not found
+	 * This is useful for addon options for example
+	 * @param attributeName
+	 * @param defaultValue
+	 * @return
+	 */	
+	Map<String, String> getAttribute(String attributeName, Map<String, String> defaultValue);
+
+	/**
+	 * return a set attribute from the runconfiguration identified by attributeName
+	 * returns the default value if not found
+	 * This is useful for addon options for example
+	 * @param attributeName
+	 * @param defaultValue
+	 * @return
+	 */	
+	Set<String> getAttribute(String attributeName, Set<String> defaultValue);
 	
 	/**
 	 * the list of enabled engine addons


### PR DESCRIPTION
## Description

Introduces some changes in the execution framework necessary for the integration of the event manager.

## Changes

This commit brings the following changes:
 - add the parameters of an execution step to methods handling such calls,
 - better implementation of the `findOperation` method in `AbstractSequentialExecutionEngine`, supporting execution rule overloading,
 - add a method to `GemocRunningEnginesRegistry` to specify an engine's name when registering it,
 - add a corresponding `_name` field in `AbstractExecutionEngine`,
 - add some methods to `IRunConfiguration` to support `Map` and `Set` launch configuration attributes,
 - remove some warnings in `org.eclipse.gemoc.executionframework.ui`.
