### PR TITLE
Fix event manager integration problems

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/build.properties
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.event.manager/build.properties
@@ -3,5 +3,4 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               schema/,\
-               pom.xml
+               schema/

--- a/framework/execution_framework/plugins/pom.xml
+++ b/framework/execution_framework/plugins/pom.xml
@@ -30,6 +30,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>org.eclipse.gemoc.executionframework.engine</module>
 		<module>org.eclipse.gemoc.executionframework.engine.model</module>
 		<module>org.eclipse.gemoc.executionframework.engine.ui</module>
+		<module>org.eclipse.gemoc.executionframework.event.manager</module>
 		<module>org.eclipse.gemoc.executionframework.event.model</module>
 		<module>org.eclipse.gemoc.executionframework.event.model.edit</module>
 		<module>org.eclipse.gemoc.executionframework.event.model.editor</module>

--- a/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/feature.xml
+++ b/framework/execution_framework/releng/org.eclipse.gemoc.executionframework.feature/feature.xml
@@ -75,6 +75,13 @@ http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.gemoc.executionframework.event.manager"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.gemoc.executionframework.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
## Description

Fixes several little oversights from the previous PR(#187), in particular a missing `<module>` declaration in the right `pom.xml`, which meant that the code from PR #187 was actually never compiled by the CI.

## Changes

- Add the event manager plugin to `framework/execution_framework/plugins/pom.xml`
- Add the event manager plugin to `org.eclipse.gemoc.executionframework.feature/feature.xml `
- Fix error in `org.eclipse.gemoc.executionframework.event.manager/build.properties`
