### PR TITLE
Fix jdom two dependencies chains issue

### DIFF
--- a/commons/plugins/org.jaxen/META-INF/MANIFEST.MF
+++ b/commons/plugins/org.jaxen/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Export-Package: org.jaxen,
  org.jaxen.saxpath.base,
  org.jaxen.saxpath.helpers,
  org.jaxen.util,
- org.jaxen.xom,
- org.w3c.dom
+ org.jaxen.xom
 Bundle-ClassPath: lib/jaxen-1.1.6.jar
 Automatic-Module-Name: org.jaxen
 Bundle-Vendor: Eclipse GEMOC Project

--- a/commons/plugins/org.jdom2/META-INF/MANIFEST.MF
+++ b/commons/plugins/org.jdom2/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Export-Package: org.jdom2,
  org.jdom2.xpath.util
 Bundle-ClassPath: libs/jdom-2.0.6.jar
 Require-Bundle: org.apache.xml.serializer;bundle-version="2.7.1",
- org.apache.xerces;bundle-version="2.9.0",
+ org.apache.xerces;bundle-version="2.12.1",
  org.jaxen;bundle-version="1.1.6",
  org.apache.xalan;bundle-version="2.7.1"
 Automatic-Module-Name: org.jdom2


### PR DESCRIPTION
## Description

Avoid an issue where some GEMOC components don't start due to a _"Bundle was not resolved because of a uses constraint violation. Unable to resolve resource org.jdom2 ... because it is exposed to package 'org.w3c.dom' from resources org.jaxen ... and org.eclipse.osgi ... via two dependency chains."_

## Changes

- remove org.w3c.dom from jaxen exported packages
- force use of xerces 2.12.1 instead of 2.9.0

 
## Contribution to issues

fixes https://github.com/eclipse/gemoc-studio/issues/239


