### PR TITLE
Disable 'allDimensions' feature in the trace edit view

### DIFF
--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.edit/src/org/eclipse/gemoc/trace/commons/model/generictrace/provider/GenericTracedObjectItemProvider.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.edit/src/org/eclipse/gemoc/trace/commons/model/generictrace/provider/GenericTracedObjectItemProvider.java
@@ -79,14 +79,14 @@ public class GenericTracedObjectItemProvider extends TracedObjectItemProvider {
 				 null,
 				 null));
 	}
-
+ 
 	/**
 	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
 	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
 	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.edit/src/org/eclipse/gemoc/trace/commons/model/generictrace/provider/GenericTracedObjectItemProvider.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.edit/src/org/eclipse/gemoc/trace/commons/model/generictrace/provider/GenericTracedObjectItemProvider.java
@@ -92,7 +92,11 @@ public class GenericTracedObjectItemProvider extends TracedObjectItemProvider {
 	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
 		if (childrenFeatures == null) {
 			super.getChildrenFeatures(object);
-			childrenFeatures.add(GenerictracePackage.Literals.GENERIC_TRACED_OBJECT__ALL_DIMENSIONS);
+			
+			// NOTE: since "dimensions" is derived from "allDimensions", we must comment 
+			// the following generated line to avoid displaying each dimension twice in the edit view
+			//
+			// childrenFeatures.add(GenerictracePackage.Literals.GENERIC_TRACED_OBJECT__ALL_DIMENSIONS);
 		}
 		return childrenFeatures;
 	}


### PR DESCRIPTION
Fixes having dimensions shown twice in the trace view (ie. with both 'dimensions' and 'allDimensions', while the former is derived from the latter)


## Description

In the trace edit view, this PR disables the display of the `allDimensions` feature of a traced object, so that only `dimensions` remains displayed.

Without this fix, the view was wrongly showing each dimension twice:
![Capture d’écran de 2022-01-06 15-17-07](https://user-images.githubusercontent.com/5868014/148396948-f856194d-a64c-414c-a372-6251f9e1a411.png)



After the fix, only `dimensions` is shown:
![Capture d’écran de 2022-01-06 15-18-22](https://user-images.githubusercontent.com/5868014/148396953-d65c5115-d1b0-42c9-9f9c-1b4b51fa0020.png)


## Changes

This comments only one line in `GenericTracedObjectItemProvider.java`.