### PR TITLE
Bump to 3.5.0

### DIFF
--- a/commons/pomfirst/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/pom.xml
+++ b/commons/pomfirst/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/pom.xml
@@ -13,7 +13,7 @@
 		<relativePath>../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/commons/pomfirst/org.eclipse.gemoc.commons.eclipse/pom.xml
+++ b/commons/pomfirst/org.eclipse.gemoc.commons.eclipse/pom.xml
@@ -13,7 +13,7 @@
 		<relativePath>../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/commons/pomfirst/org.eclipse.gemoc.dsl.model/pom.xml
+++ b/commons/pomfirst/org.eclipse.gemoc.dsl.model/pom.xml
@@ -13,7 +13,7 @@
 		<relativePath>../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/commons/releng/org.eclipse.gemoc.commons.feature/feature.xml
+++ b/commons/releng/org.eclipse.gemoc.commons.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.commons.feature"
       label="GEMOC Commons"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/pomfirst/pom.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.debugger/pomfirst/pom.xml
@@ -13,7 +13,7 @@
 		<relativePath>../../../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/pom.xml
+++ b/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/pom.xml
@@ -14,7 +14,7 @@
 		<relativePath>../../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 	<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
  
     <packaging>pom</packaging>
 	<url>https://www.eclipse.org/gemoc/</url>
@@ -120,7 +120,7 @@
 			<dependency>
 				<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 				<artifactId>gemoc-studio-bom</artifactId>
-				<version>3.4.0-SNAPSHOT</version>
+				<version>3.5.0-SNAPSHOT</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>

--- a/releng/org.eclipse.gemoc.modeldebugging.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.modeldebugging.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.modeldebugging.feature"
       label="GEMOC ModelDebugging"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug.edit/pom.xml
+++ b/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug.edit/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>/../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug.ide/pom.xml
+++ b/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug.ide/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug/pom.xml
+++ b/simulationmodelanimation/pomfirst/org.eclipse.gemoc.dsl.debug/pom.xml
@@ -14,7 +14,7 @@
 		<relativePath>../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/pom.xml
@@ -14,7 +14,7 @@
 		<relativePath>../../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.gemoc.api/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.gemoc.api/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../../../../pomfirst</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-modeldebugging</groupId>
 		<artifactId>org.eclipse.gemoc.modeldebugging.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
## Description

Bump GEMOC Studio version to 3.5.0

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/254
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/64
 - https://github.com/eclipse/gemoc-studio-moccml/pull/22
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/51
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/22
 