### PR TITLE
Bump eclipse 2021 12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.2.0</version>
+    <version>2.6.0</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.6.0</version>
+    <version>2.5.0</version>
   </extension>
 </extensions>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>2.2.0</tycho-version>
+		<tycho-version>2.5.0</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 

--- a/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/.classpath
+++ b/trace/manager/plugins/org.eclipse.gemoc.addon.diffviewer/.classpath
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-<<<<<<< HEAD
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
-=======
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
->>>>>>> branch 'master' of https://github.com/eclipse/gemoc-studio-modeldebugging.git
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>


### PR DESCRIPTION
## Description

Bump Eclipse base IDE to 2021-12
use corresponding tycho (2.5.0) and xtend/xtext (2.25.0)

## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio/pull/255
- https://github.com/eclipse/gemoc-studio-execution-java/pull/23
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/52
- https://github.com/eclipse/gemoc-studio-moccml/pull/23
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/65
