### PR TITLE
Prevent NPE in Sirius if a model element doesn't have an eResource

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DebugPermissionAuthority.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.extensions.sirius/src/org/eclipse/gemoc/executionframework/extensions/sirius/modelloader/DebugPermissionAuthority.java
@@ -49,24 +49,28 @@ public class DebugPermissionAuthority extends AbstractPermissionAuthority
 
 	@Override
 	public boolean canEditFeature(EObject eObj, String featureName) {
+		if(eObj.eResource() == null) return true;
 		Integer integer = allow.get(eObj.eResource().getResourceSet());
 		return integer != null && integer.intValue() > 0;
 	}
 
 	@Override
 	public boolean canEditInstance(EObject eObj) {
+		if(eObj.eResource() == null) return true;
 		Integer integer = allow.get(eObj.eResource().getResourceSet());
 		return integer != null && integer.intValue() > 0;
 	}
 
 	@Override
 	public boolean canCreateIn(EObject eObj) {
+		if(eObj.eResource() == null) return true;
 		Integer integer = allow.get(eObj.eResource().getResourceSet());
 		return integer != null && integer.intValue() > 0;
 	}
 
 	@Override
 	public boolean canDeleteInstance(EObject target) {
+		if(target.eResource() == null) return true;
 		Integer integer = allow.get(target.eResource().getResourceSet());
 		return integer != null && integer.intValue() > 0;
 	}


### PR DESCRIPTION

## Description

In some graphical representation we may sometime get DNode model element  without eResource (I don't really know why :disappointed:  ), when used  in GEMOC simulation,this raises NPE when it tries to get the permission to edit/create/delete the element
cf. org.eclipse.gemoc.executionframework.extensions.sirius.modelloaderebugPermissionAuthority 

 ## Changes

- This PR adds simple verification to allow such edition if the element isn't in a resource (I consider that if it has no eResoure, this means the element is probably dynamic and can be edited.
 