### PR TITLE
Use tpd for defining target platform

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -40,10 +40,6 @@
 	</build>
  
 	<repositories>
-		<repository>
-			<id>Eclipse release</id>
-			<layout>p2</layout>
-			<url>${eclipse.release.p2.url}</url>
-		</repository>
+
 	</repositories>
 </project>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -386,7 +386,7 @@ public abstract class AbstractExecutionEngine<C extends IExecutionContext<R, ?, 
 			currentTransaction.getCommand().dispose();
 	}
 
-	private void commitCurrentTransaction() {
+	private synchronized void commitCurrentTransaction() {
 		if (currentTransaction != null) {
 			try {
 				currentTransaction.commit();

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -18,11 +18,7 @@
 	</modules>
 
 	<repositories>
-		<repository>
-			<id>Eclipse release</id>
-			<layout>p2</layout>
-			<url>${eclipse.release.p2.url}</url>
-		</repository>
+		
 		<repository>
 			<id>K3</id>
 			<layout>p2</layout>
@@ -32,12 +28,6 @@
 			<id>Melange</id>
 			<layout>p2</layout>
 			<url>${melange.p2.url}</url>
-		</repository>
-		<!--  e(fxc)lipse updatesite is currently required because they dropped from the release train -->
-		<repository>
-			<id>efxclipse</id>
-			<layout>p2</layout>
-			<url>${efxclipse.p2.url}</url>
 		</repository>
 	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,14 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<target>
+                        <artifact>
+                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+                            <version>3.5.0-SNAPSHOT</version>
+                            <classifier>gemoc_studio</classifier>
+                        </artifact>
+                    </target>
 					<!-- environments that will be built -->
 					<environments>
 						<environment>

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -65,11 +65,7 @@
 	</dependencies>
 	   
     <repositories>
-    	<repository>
-    		<id>Eclipse release</id>
-            <layout>p2</layout>
-            <url>${eclipse.release.p2.url}</url>
-    	</repository>
+    	
     	<repository>
     		<id>K3</id>
             <layout>p2</layout>
@@ -80,21 +76,6 @@
             <layout>p2</layout>
             <url>${melange.p2.url}</url>
     	</repository>
-    	<repository>
-    		<id>ELK</id>
-            <layout>p2</layout>
-            <url>${elk.p2.url}</url>
-    	</repository>
-		<!--  e(fxc)lipse updatesite is currently required because they dropped from the release train -->
-		<repository>
-			<id>efxclipse</id>
-			<layout>p2</layout>
-			<url>${efxclipse.p2.url}</url>
-		</repository>
-        <repository>
-			<id>efxclipse2</id>
-			<layout>p2</layout>
-			<url>${efxclipse2.p2.url}</url>
-		</repository>
+    	
     </repositories>
 </project>


### PR DESCRIPTION
## Description
This PR changes the way the external update sites are imported in the build.
Instead of using maven repository like:
```
	<repositories>
		<repository>
			<id>Eclipse release</id>
			<layout>p2</layout>
			<url>${eclipse.release.p2.url}</url>
		</repository>
```
It uses a tpd description file in order to generate a targetplatform file.
This tpd allows to not specify precisely the version of the imported unit while helping to control where they come from.

A readme file explains how to update the target file from the tpd (in `gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform`)

NOTE: the use of the tpd is partial: the K3 and melange updatesite currently cannot be integrated in the target because these tools depends on gemoc.dsl that is actually build by GEMOC. This creates a kind of cycle in the targetplatfomr :disappointed: . Melange an K3 as thus still using the maven repository descriptor.

Additionally, the integration tests now explicitly use the gemoc product and target (this fix the javafx error preventing from opening the multidimentional view in the tests)

 :disappointed: I was expecting a speed up in the build (https://github.com/eclipse/gemoc-studio/issues/233) but, apparently, the newer version of tycho are optimized enough and there is no visible speed change.
 
## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/233


## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/259
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/216
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/66
 - https://github.com/eclipse/gemoc-studio-moccml/pull/24
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/53
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/24
