### PR TITLE
Fix: provide args to step factory

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
@@ -149,7 +149,7 @@ public abstract class AbstractSequentialExecutionEngine<C extends IExecutionCont
 			occurrence.setMse(mse);
 			result = step;
 		} else {
-			result = traceAddon.getFactory().createStep(mse, new ArrayList<Object>(), new ArrayList<Object>());
+			result = traceAddon.getFactory().createStep(mse, args, new ArrayList<Object>());
 		}
 		result.getMseoccurrence().getParameters().addAll(Arrays.asList(args));
 		return result;


### PR DESCRIPTION
## Description

When a trace addon is used, the parameters of a step and not provided to the step factory of the trace addon.

This PR fixes this discrepancy. 