### PR TITLE
Bump to version of k3 including StepCommand return null fix

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractCommandBasedSequentialExecutionEngine.xtend
@@ -11,11 +11,11 @@
 package org.eclipse.gemoc.executionframework.engine.core
 
 import java.util.Arrays
+import java.util.List
 import java.util.concurrent.Callable
 import org.eclipse.emf.transaction.RecordingCommand
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionContext
 import org.eclipse.gemoc.xdsmlframework.api.core.IRunConfiguration
-import java.util.Optional
 
 abstract class AbstractCommandBasedSequentialExecutionEngine<C extends IExecutionContext<R, ?, ?>, R extends IRunConfiguration> extends AbstractSequentialExecutionEngine<C, R> {
 
@@ -28,14 +28,14 @@ abstract class AbstractCommandBasedSequentialExecutionEngine<C extends IExecutio
 	 * @param operation
 	 */
 	protected def void executeOperation(Object caller, String className, String operationName,
-		Callable<Optional<Object>> operation) {
+		Callable<List<Object>> operation) {
 		executeOperation(caller, #{}, className, operationName, operation);
 	}
 
-	var Optional<Object> lastResult = null
+	var List<Object> lastResult = null
 
 	protected def void executeOperation(Object caller, Object[] parameters, String className, String operationName,
-		Callable<Optional<Object>> operation) {
+		Callable<List<Object>> operation) {
 		val RecordingCommand rc = new RecordingCommand(editingDomain) {
 			override doExecute() {
 				AbstractCommandBasedSequentialExecutionEngine.this.lastResult = operation.call()

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractExecutionEngine.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -518,17 +517,17 @@ public abstract class AbstractExecutionEngine<C extends IExecutionContext<R, ?, 
 	/**
 	 * To be called just after each execution step by an implementing engine.
 	 */
-	protected void afterExecutionStep(Optional<Object> returnValue) {
+	protected void afterExecutionStep(List<Object> returnValue) {
 
 		RecordingCommand emptyrc = null;
 
 		try {
 
 			Step<?> step = currentSteps.pop();
-			if (returnValue.isPresent()) {
-				step.getMseoccurrence().getResult().add(returnValue.get());
+			if (!returnValue.isEmpty()) {
+				step.getMseoccurrence().getResult().add(returnValue.get(0));
 			}
-			
+
 			// We commit the transaction (which might be a different one
 			// than the one created earlier, or null if two operations
 			// end successively)

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine/src/org/eclipse/gemoc/executionframework/engine/core/AbstractSequentialExecutionEngine.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EClass;
@@ -91,7 +90,7 @@ public abstract class AbstractSequentialExecutionEngine<C extends IExecutionCont
 	}
 
 	@Override
-	protected final void afterExecutionStep(Optional<Object> returnValue) {
+	protected final void afterExecutionStep(List<Object> returnValue) {
 		super.afterExecutionStep(returnValue);
 	}
 


### PR DESCRIPTION
## Description

Bump to the latest version of K3 that includes the support for all kind of StepCommand (ie. result being void, null or an object)

## Changes

Adapt the framework to the new return structure (iea List)
 

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/284
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/59
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/30
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/74
