### PR TITLE
Bump to eclipse 2023 06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.3</version>
+		<version>3.0.4</version>
 	</extension>
 </extensions>

--- a/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/pom.xml
+++ b/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/pom.xml
@@ -27,7 +27,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -44,7 +43,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,8 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+				   	<!-- Optional set the Java version you are using-->
+	    		    <executionEnvironment>JavaSE-17</executionEnvironment>
 					<target>
                         <artifact>
                             <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->	
 				
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
 		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
@@ -95,23 +95,20 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
+					<execution>
+			            <id>feature-source</id>
+			            <goals>
+			              <goal>feature-source</goal>
+			            </goals>
+			            <configuration>
+			              <excludes>
+			                <!-- provide plug-ins not containing any source code -->
+			                <!-- also possible to exclude feature-->
+			              </excludes>
+			            </configuration>
+          			</execution>
 				</executions>
 			</plugin>
-			<!-- enable source feature generation -->
-			<plugin>
-		      <groupId>org.eclipse.tycho.extras</groupId>
-		      <artifactId>tycho-source-feature-plugin</artifactId>
-		      <version>${tycho-version}</version>
-		      <executions>
-		        <execution>
-		          <id>source-feature</id>
-		          <phase>package</phase>
-		          <goals>
-		            <goal>source-feature</goal>
-		          </goals>
-		        </execution>
-		      </executions>
-		    </plugin>
 		    <plugin>
 		     <groupId>org.eclipse.tycho</groupId>
 		     <artifactId>tycho-p2-plugin</artifactId>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -37,8 +37,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
 	</properties>
 	

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -33,7 +33,7 @@
 	
 	<properties>
 		<tycho.version>1.5.1</tycho.version>
-		<xtend.version>2.27.0</xtend.version>
+		<xtend.version>2.31.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -33,14 +33,13 @@
 	
 	<properties>
 		<tycho.version>1.5.1</tycho.version>
-		<xtend.version>2.18.0</xtend.version>
+		<xtend.version>2.27.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	
 		
@@ -106,8 +105,26 @@
 					</dependency>
 				</dependencies> -->
 			</plugin>
-
 		</plugins>
+		
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.2.0</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-compiler-plugin</artifactId>
+	                <version>3.8.1</version>
+	            </plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	
 

--- a/protocols/engine_addon_protocol/plugins/org.eclipse.gemoc.protocols.eaop.api/src/org/eclipse/gemoc/protocols/eaop/api/data/util/ToStringBuilder.java
+++ b/protocols/engine_addon_protocol/plugins/org.eclipse.gemoc.protocols.eaop.api/src/org/eclipse/gemoc/protocols/eaop/api/data/util/ToStringBuilder.java
@@ -1,0 +1,381 @@
+package org.eclipse.gemoc.protocols.eaop.api.data.util;
+
+/**
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+
+
+/**
+ * Helps with the construction of good {@link Object#toString()} representations.
+ * <p>You can customize the output using the builder-style methods {@link ToStringBuilder#singleLine()} {@link ToStringBuilder#skipNulls()} and {@link ToStringBuilder#hideFieldNames()}.</p>
+ * <p>You can either directly list fields to include via {@link ToStringBuilder#add(String, Object)} and {@link ToStringBuilder#add(Object)}
+ * or you can let the builder do it automatically using reflection, either including the fields declared in this class or including all superclasses.</p>
+ * <p>The builder will automatically handle cycles in the object tree. It also pretty prints arrays and Iterables.</p>
+ *
+ * This class is not thread safe.
+ * @since 2.7
+ */
+public final class ToStringBuilder {
+	
+	public static class ToStringContext {
+
+		public final static ToStringContext INSTANCE = new ToStringContext();
+
+		private final static ThreadLocal<IdentityHashMap<Object, Boolean>> currentlyProcessed = new ThreadLocal<IdentityHashMap<Object, Boolean>>() {
+			@Override
+			public IdentityHashMap<Object, Boolean> initialValue() {
+				return new IdentityHashMap<Object, Boolean>();
+			}
+		};
+
+		public boolean startProcessing(final Object obj) {
+			return ToStringContext.currentlyProcessed.get().put(obj, Boolean.TRUE) == null;
+		}
+
+		public void endProcessing(final Object obj) {
+			ToStringContext.currentlyProcessed.get().remove(obj);
+		}
+	}
+	
+	private static ToStringContext toStringContext = ToStringContext.INSTANCE;
+	
+	private final Object instance;
+
+	private final String typeName;
+
+	private boolean multiLine = true;
+
+	private boolean skipNulls = false;
+
+	private boolean showFieldNames = true;
+
+	private boolean prettyPrint = true;
+
+	private final List<Part> parts = new ArrayList<Part>();
+
+	/**
+	 * Creates a new ToStringBuilder for the given object. If you don't use reflection, then this instance
+	 * is only used for obtaining its classes' simple name.
+	 *
+	 * @param instance the object to convert to a String
+	 */
+	public ToStringBuilder(final Object instance) {
+		this.instance = instance;
+		this.typeName = instance.getClass().getSimpleName();
+	}
+
+	/**
+	 * Fields are printed on a single line, separated by commas instead of newlines
+	 * @return this
+	 */
+	public ToStringBuilder singleLine() {
+		this.multiLine = false;
+		return this;
+	}
+
+	/**
+	 * Fields with null values will be excluded from the output
+	 * @return this
+	 */
+	public ToStringBuilder skipNulls() {
+		this.skipNulls = true;
+		return this;
+	}
+
+	/**
+	 * Field names will not be included in the output. Useful for small classes.
+	 * @return this
+	 */
+	public ToStringBuilder hideFieldNames() {
+		this.showFieldNames = false;
+		return this;
+	}
+
+	/**
+	 * By default, Iterables, Arrays and multiline Strings are pretty-printed.
+	 * Switching to their normal representation makes the toString method significantly faster.
+	 * @since 2.9
+	 * @return this
+	 */
+	public ToStringBuilder verbatimValues() {
+		this.prettyPrint = false;
+		return this;
+	}
+
+	/**
+	 * Adds all fields declared directly in the object's class to the output
+	 * @return this
+	 */
+	public ToStringBuilder addDeclaredFields() {
+		Field[] fields = instance.getClass().getDeclaredFields();
+		for(Field field : fields) {
+			addField(field);
+		}
+		return this;
+	}
+
+	/**
+	 * Adds all fields declared in the object's class and its superclasses to the output.
+	 * @return this
+	 */
+	public ToStringBuilder addAllFields() {
+		List<Field> fields = getAllDeclaredFields(instance.getClass());
+		for(Field field : fields) {
+			addField(field);
+		}
+		return this;
+	}
+
+	/**
+	 * @param fieldName the name of the field to add to the output using reflection
+	 * @return this
+	 */
+	public ToStringBuilder addField(final String fieldName) {
+		List<Field> fields = getAllDeclaredFields(instance.getClass());
+		for(Field field : fields) {
+			if(fieldName.equals(field.getName())) {
+				addField(field);
+				break;
+			}
+		}
+		return this;
+	}
+
+	private ToStringBuilder addField(final Field field) {
+		if (!Modifier.isStatic(field.getModifiers())) {
+			field.setAccessible(true);
+			try {
+				add(field.getName(), field.get(instance));
+			} catch(IllegalAccessException e) {
+				sneakyThrow(e);
+			}
+		}
+		return this;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
+		throw (T) t;
+	}
+
+	/**
+	 * @param value the value to add to the output
+	 * @param fieldName the field name to list the value under
+	 * @return this
+	 */
+	public ToStringBuilder add(final String fieldName, final Object value) {
+		return addPart(fieldName, value);
+	}
+
+	/**
+	 * @param value the value to add to the output without a field name
+	 * @return this
+	 */
+	public ToStringBuilder add(final Object value) {
+		return addPart(value);
+	}
+
+	private Part addPart() {
+		final Part p = new Part();
+		this.parts.add(p);
+		return p;
+	}
+
+	private ToStringBuilder addPart(final Object value) {
+		final Part p = this.addPart();
+		p.value = value;
+		return this;
+	}
+
+	private ToStringBuilder addPart(final String fieldName, final Object value) {
+		final Part p = this.addPart();
+		p.fieldName = fieldName;
+		p.value = value;
+		return this;
+	}
+
+	/**
+	 * @return the String representation of the processed object
+	 */
+	@Override
+	public String toString() {
+		boolean startProcessing = ToStringBuilder.toStringContext.startProcessing(this.instance);
+		if (!startProcessing) {
+			return this.toSimpleReferenceString(this.instance);
+		}
+		try {
+			final IndentationAwareStringBuilder builder = new IndentationAwareStringBuilder();
+			builder.append(typeName).append(" ");
+			builder.append("[");
+			String nextSeparator = "";
+			if (multiLine) {
+				builder.increaseIndent();
+			}
+			for (Part part : parts) {
+				if (!skipNulls || part.value != null) {
+					if (multiLine) {
+						builder.newLine();
+					} else {
+						builder.append(nextSeparator);
+						nextSeparator = ", ";
+					}
+					if (part.fieldName != null && this.showFieldNames) {
+						builder.append(part.fieldName).append(" = ");
+					}
+					this.internalToString(part.value, builder);
+				}
+			}
+			if (multiLine) {
+				builder.decreaseIndent().newLine();
+			}
+			builder.append("]");
+			return builder.toString();
+		} finally {
+			ToStringBuilder.toStringContext.endProcessing(this.instance);
+		}
+	}
+
+	private void internalToString(final Object object, final IndentationAwareStringBuilder sb) {
+		if (prettyPrint) {
+			if (object instanceof Iterable<?>) {
+				serializeIterable((Iterable<?>)object, sb);
+			} else if (object instanceof Object[]) {
+				sb.append(Arrays.toString((Object[])object));
+			} else if (object instanceof byte[]) {
+				sb.append(Arrays.toString((byte[])object));
+			} else if (object instanceof char[]) {
+				sb.append(Arrays.toString((char[])object));
+			} else if (object instanceof int[]) {
+				sb.append(Arrays.toString((int[])object));
+			} else if (object instanceof boolean[]) {
+				sb.append(Arrays.toString((boolean[])object));
+			} else if (object instanceof long[]) {
+				sb.append(Arrays.toString((long[])object));
+			} else if (object instanceof float[]) {
+				sb.append(Arrays.toString((float[])object));
+			} else if (object instanceof double[]) {
+				sb.append(Arrays.toString((double[])object));
+			} else if (object instanceof CharSequence) {
+				sb.append("\"").append(((CharSequence)object).toString().replace("\n", "\\n").replace("\r", "\\r")).append("\"");
+			} else if (object instanceof Enum<?>) {
+				sb.append(((Enum<?>)object).name());
+			} else {
+				sb.append(String.valueOf(object));
+			}
+		} else {
+			sb.append(String.valueOf(object));
+		}
+	}
+
+	private void serializeIterable(final Iterable<?> object, final IndentationAwareStringBuilder sb) {
+		final Iterator<?> iterator = object.iterator();
+		sb.append(object.getClass().getSimpleName()).append(" (");
+		if (multiLine) {
+			sb.increaseIndent();
+		}
+		boolean wasEmpty = true;
+		while (iterator.hasNext()) {
+			wasEmpty = false;
+			if (multiLine) {
+				sb.newLine();
+			}
+			this.internalToString(iterator.next(), sb);
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+		if (multiLine) {
+			sb.decreaseIndent();
+		}
+		if (!wasEmpty && this.multiLine) {
+			sb.newLine();
+		}
+		sb.append(")");
+	}
+
+	private String toSimpleReferenceString(final Object obj) {
+		String simpleName = obj.getClass().getSimpleName();
+		int identityHashCode = System.identityHashCode(obj);
+		return simpleName + "@" + Integer.valueOf(identityHashCode);
+	}
+
+	private List<Field> getAllDeclaredFields(final Class<?> clazz) {
+		final ArrayList<Field> result = new ArrayList<>();
+
+		for(Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+			Field[] declaredFields = current.getDeclaredFields();
+			result.addAll(Arrays.asList(declaredFields));
+			
+		}
+		return result;
+	}
+
+	private static final class Part {
+		private String fieldName;
+		private Object value;
+	}
+
+	private static class IndentationAwareStringBuilder {
+		private final StringBuilder builder = new StringBuilder();
+
+		private final String indentationString = "  ";
+
+		private final String newLineString = "\n";
+
+		private int indentation = 0;
+
+		public IndentationAwareStringBuilder increaseIndent() {
+			indentation++;
+			return this;
+		}
+
+		public IndentationAwareStringBuilder decreaseIndent() {
+			indentation--;
+			return this;
+		}
+
+		public IndentationAwareStringBuilder append(final CharSequence string) {
+			if (indentation > 0) {
+				String indented = string.toString().replace(
+					newLineString,
+					newLineString + repeat(indentationString, indentation)
+				);
+				builder.append(indented);
+			} else {
+				builder.append(string);
+			}
+			return this;
+		}
+
+		public IndentationAwareStringBuilder newLine() {
+			builder.append(newLineString).
+			append(repeat(this.indentationString, this.indentation));
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			return this.builder.toString();
+		}
+		
+		private String repeat(String string, int count) {
+			StringBuilder result = new StringBuilder();
+			for(int i=0; i < count; i++) {
+				result.append(string);
+			}
+			return result.toString();
+		}
+	}
+}

--- a/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/pom.xml
+++ b/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/pom.xml
@@ -23,13 +23,26 @@
 
 	<build>
 		<plugins>
-			
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/src/main/java</outputDirectory>
+							<resources>
+								<resource>
+									<directory>../../plugins/org.eclipse.gemoc.protocols.eaop.api/src</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>copy-resource-src-gen</id>
 						<phase>generate-sources</phase>
 						<goals>
 							<goal>copy-resources</goal>
@@ -48,7 +61,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -101,12 +113,18 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.ide.common</artifactId>
-	
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.xbase.lib</artifactId>
 		</dependency>
-
+		<dependency>
+		    <groupId>org.eclipse.lsp4j</groupId>
+		    <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.eclipse.lsp4j</groupId>
+		    <artifactId>org.eclipse.lsp4j.generator</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -49,6 +49,8 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+				   	<!-- Optional set the Java version you are using-->
+	    		    <executionEnvironment>JavaSE-17</executionEnvironment>
 					<resolver>p2</resolver>
 					<environments>
 						<environment>

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -27,7 +27,7 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>2.7.3</tycho-version>
+		<tycho-version>3.0.4</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/SiriusLab/ModelDebugging.git</tycho.scmUrl>
 	</properties>
 

--- a/simulationmodelanimation/pom.xml
+++ b/simulationmodelanimation/pom.xml
@@ -109,8 +109,8 @@
 				<version>${tycho-version}</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
-					<source>11</source>
-					<target>11</target>					
+					<source>17</source>
+					<target>17</target>					
 				</configuration>
 			</plugin>
 			<!-- enable source bundle generation -->
@@ -125,21 +125,18 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-				</executions>
-			</plugin>
-			<!-- enable source feature generation -->
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
 					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
+			            <id>feature-source</id>
+			            <goals>
+			              <goal>feature-source</goal>
+			            </goals>
+			            <configuration>
+			              <excludes>
+			                <!-- provide plug-ins not containing any source code -->
+			                <!-- also possible to exclude feature-->
+			              </excludes>
+			            </configuration>
+          			</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons/src/org/eclipse/gemoc/trace/commons/ManifestUtil.java
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons/src/org/eclipse/gemoc/trace/commons/ManifestUtil.java
@@ -21,16 +21,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.jar.Attributes;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.IJavaProject;
-//import org.eclipse.xtend.ide.buildpath.XtendLibClasspathAdder;
-import org.eclipse.xtext.util.MergeableManifest;
+import org.eclipse.xtext.util.MergeableManifest2;
+import org.eclipse.xtext.util.MergeableManifest2.Attributes;
 
 /**
  * Code taken from XtendLibClasspathAdder
@@ -38,14 +36,13 @@ import org.eclipse.xtext.util.MergeableManifest;
  * @author ebousse
  *
  */
-@SuppressWarnings("restriction")
 public class ManifestUtil {
 
-	private static MergeableManifest createMergableManifest(
+	private static MergeableManifest2 createMergableManifest(
 			IResource manifestFile) throws IOException, CoreException {
 		InputStream originalManifest = ((IFile) manifestFile).getContents();
 		try {
-			return new MergeableManifest(originalManifest);
+			return new MergeableManifest2(originalManifest);
 		} finally {
 			originalManifest.close();
 		}
@@ -61,7 +58,7 @@ public class ManifestUtil {
 			OutputStream output = null;
 			InputStream input = null;
 			try {
-				MergeableManifest manifest = createMergableManifest(manifestFile);
+				MergeableManifest2 manifest = createMergableManifest(manifestFile);
 				List<String> plunginsToAdd = new ArrayList<String>();
 				plunginsToAdd.add(pluginToAdd);
 				manifest.addRequiredBundles(newHashSet(plunginsToAdd));
@@ -93,9 +90,9 @@ public class ManifestUtil {
 			OutputStream output = null;
 			InputStream input = null;
 			try {
-				MergeableManifest manifest = createMergableManifest(manifestFile);
+				MergeableManifest2 manifest = createMergableManifest(manifestFile);
 				Attributes atts = manifest.getMainAttributes();
-				atts.putValue("Bundle-RequiredExecutionEnvironment", requiredExecutionEnvironment);
+				atts.put("Bundle-RequiredExecutionEnvironment", requiredExecutionEnvironment);
 				ByteArrayOutputStream out = new ByteArrayOutputStream();
 				output = new BufferedOutputStream(out);
 				manifest.write(output);

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -42,7 +41,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/pom.xml
@@ -27,7 +27,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -44,7 +43,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>
@@ -70,7 +68,7 @@
 			<plugin> <!--  force build order in generate-sources phase -->
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				
+				<!--
 				<dependencies>
 					<dependency>
 						<groupId>org.eclipse.jdt</groupId>
@@ -92,7 +90,7 @@
 						<artifactId>org.eclipse.emf.codegen</artifactId>
 						<version>2.11.0</version>
 					</dependency>
-				</dependencies>
+				</dependencies>-->
 			</plugin>
 		</plugins>
 	</build>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.gemoc.api/pom.xml
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.gemoc.api/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -42,7 +41,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>

--- a/trace/manager/pom.xml
+++ b/trace/manager/pom.xml
@@ -20,7 +20,7 @@
 	</modules>
 
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -18,7 +18,7 @@
     </modules>
  
  	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
  


### PR DESCRIPTION
## Description

Upgrade the base Eclipse to Eclipse 2023-06.
Applies the changes required by the new version of components (XText, Xtend, Sirius)
New minimal requirement : java 17

## Changes

<!-- more details , changed documentation sections, changed version, some details about the code changes -->
 
 - Use java 17 in the CI docker image
 - new splash screen
 - use tycho 3.0.4
 - use xtend 2.31
 - use lsp4j 0.21 + adaptation to this version (toStringBuilder class)
 - change maven plugin for generating plantuml images
 - fix melangeK3FSM project nature
 - remove use of deprecated xtext.MergeableManifest
 
## Contribution to issues

Contribute to #298 

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/299
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/232
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/61
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/32
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/77
 - https://github.com/eclipse/gemoc-studio-moccml/pull/28
 - https://github.com/eclipse/gemoc-studio-commons/pull/4