### PR TITLE
Centralize property tester and earlystartup in modeldebugging

### DIFF
--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/META-INF/MANIFEST.MF
@@ -30,7 +30,8 @@ Require-Bundle: org.eclipse.gemoc.xdsmlframework.api,
  org.eclipse.gemoc.executionframework.ui,
  org.eclipse.sirius.ui,
  org.eclipse.ui.workbench,
- org.eclipse.ui.ide;bundle-version="3.14.0"
+ org.eclipse.ui.ide;bundle-version="3.14.0",
+ org.eclipse.core.expressions
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.gemoc.executionframework.engine.ui,

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/plugin.xml
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/plugin.xml
@@ -1,99 +1,116 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension
-         point="org.eclipse.debug.ui.debugModelPresentations">
-      <debugModelPresentation
-            class="org.eclipse.gemoc.executionframework.engine.ui.genericdebugmodel.GemocGenericDebugModelPresentation"
-            id="org.eclipse.gemoc.executionframework.engine.ui.generic.debugModel">
-      </debugModelPresentation>
-   </extension>
-   <extension
-         point="org.eclipse.debug.core.sourceLocators">
-      <sourceLocator
-            class="org.eclipse.gemoc.executionframework.engine.ui.genericdebugmodel.GemocGenericSourceLocator"
-            id="org.eclipse.gemoc.executionframework.engine.ui.generic.sourceLocator"
-            name="GEMOC Generic Source Locator">
-      </sourceLocator>
-   </extension>
-   
-   
-       <extension
-         point="org.eclipse.gemoc.gemoc_language_workbench.deciders">
-      <DeciderSpecification
-            Class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.deciders.StepByStepUserDecider"
-            Icon="icons/user-shield-green-16.png"
-            Name="Step by step user decider">
-      </DeciderSpecification>
-      <DeciderSpecification
-            Class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.deciders.UserDecider"
-            Icon="icons/user-shield-black-16.png"
-            Name="User decider">
-      </DeciderSpecification>
+	<extension
+		point="org.eclipse.debug.ui.debugModelPresentations">
+		<debugModelPresentation
+			class="org.eclipse.gemoc.executionframework.engine.ui.genericdebugmodel.GemocGenericDebugModelPresentation"
+			id="org.eclipse.gemoc.executionframework.engine.ui.generic.debugModel">
+		</debugModelPresentation>
 	</extension>
-	
-	  <extension
-            point="org.eclipse.ui.views">
-               <category
-	            id="org.eclipse.gemoc.executionframework.ui.category"
-	            name="Gemoc">
-	      </category>
-	      
-	      	      <view
-	            category="org.eclipse.gemoc.executionframework.ui.category"
-	            class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.views.step.LogicalStepsView"
-	            icon="icons/IconeGemocModel-16.png"
-	            id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
-	            name="Concurrent Logical Steps Decider">
-	      </view>
-	      
-	      	      <view
-	            category="org.eclipse.gemoc.executionframework.ui.category"
-	            class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.strategyselector.StrategySelectionView"
-	            icon="icons/IconeGemocModel-16.png"
-	            id="org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
-	            name="Strategy Selection">
-	      </view>
-            
-            
+	<extension
+		point="org.eclipse.debug.core.sourceLocators">
+		<sourceLocator
+			class="org.eclipse.gemoc.executionframework.engine.ui.genericdebugmodel.GemocGenericSourceLocator"
+			id="org.eclipse.gemoc.executionframework.engine.ui.generic.sourceLocator"
+			name="GEMOC Generic Source Locator">
+		</sourceLocator>
 	</extension>
-	
-	 <extension
-         point="org.eclipse.ui.perspectiveExtensions">
-         <perspectiveExtension
-          targetID="org.eclipse.sirius.ui.tools.perspective.modeling">
-          
-            <view
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
-               minimized="false"
-               relationship="stack"
-               relative="org.eclipse.sirius.ui.tools.views.model.explorer"
-               visible="true">
-         </view>
-          
-              <viewShortcut
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView">
-         </viewShortcut>
-          
-          </perspectiveExtension>
-           <perspectiveExtension
-            targetID="org.eclipse.debug.ui.DebugPerspective">
-            
-            
-              <view
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
-               minimized="false"
-               ratio="0.5"
-               relationship="bottom"
-               relative="org.eclipse.gemoc.executionframework.ui.views.engine.EnginesStatusView"
-               visible="true">
-         </view>
-            
-               <viewShortcut
-               id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView">
-         </viewShortcut>
-            
-            
-           </perspectiveExtension>
-         </extension>
+
+
+	<extension
+		point="org.eclipse.gemoc.gemoc_language_workbench.deciders">
+		<DeciderSpecification
+			Class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.deciders.StepByStepUserDecider"
+			Icon="icons/user-shield-green-16.png"
+			Name="Step by step user decider">
+		</DeciderSpecification>
+		<DeciderSpecification
+			Class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.deciders.UserDecider"
+			Icon="icons/user-shield-black-16.png"
+			Name="User decider">
+		</DeciderSpecification>
+	</extension>
+
+	<extension
+		point="org.eclipse.ui.views">
+		<category
+			id="org.eclipse.gemoc.executionframework.ui.category"
+			name="Gemoc">
+		</category>
+
+		<view
+			category="org.eclipse.gemoc.executionframework.ui.category"
+			class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.views.step.LogicalStepsView"
+			icon="icons/IconeGemocModel-16.png"
+			id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
+			name="Concurrent Logical Steps Decider">
+		</view>
+
+		<view
+			category="org.eclipse.gemoc.executionframework.ui.category"
+			class="org.eclipse.gemoc.executionframework.engine.ui.concurrency.strategyselector.StrategySelectionView"
+			icon="icons/IconeGemocModel-16.png"
+			id="org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
+			name="Strategy Selection">
+		</view>
+
+
+	</extension>
+
+	<extension
+		point="org.eclipse.ui.perspectiveExtensions">
+		<perspectiveExtension
+			targetID="org.eclipse.sirius.ui.tools.perspective.modeling">
+
+			<view
+				id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
+				minimized="false"
+				relationship="stack"
+				relative="org.eclipse.sirius.ui.tools.views.model.explorer"
+				visible="true">
+			</view>
+
+			<viewShortcut
+				id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView">
+			</viewShortcut>
+
+		</perspectiveExtension>
+		<perspectiveExtension
+			targetID="org.eclipse.debug.ui.DebugPerspective">
+
+
+			<view
+				id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView"
+				minimized="false"
+				ratio="0.5"
+				relationship="bottom"
+				relative="org.eclipse.gemoc.executionframework.ui.views.engine.EnginesStatusView"
+				visible="true">
+			</view>
+
+			<viewShortcut
+				id="org.eclipse.gemoc.executionframework.engine.io.views.steps.LogicalStepsView">
+			</viewShortcut>
+
+
+		</perspectiveExtension>
+	</extension>
+	<extension
+		point="org.eclipse.core.expressions.propertyTesters">
+		<propertyTester
+			class="org.eclipse.gemoc.executionframework.engine.ui.propertytesters.GemocXDSMLPropertyTester"
+			id="org.eclipse.gemoc.executionframework.engine.ui.propertytesters.GemocXDSMLPropertyTester"
+			namespace="org.eclipse.gemoc.executionframework.engine.ui.propertytesters"
+			properties="isModel, isExecutableDomainSpecificModel"
+			type="org.eclipse.core.runtime.IAdaptable">
+		</propertyTester>
+	</extension>
+
+	<extension
+		point="org.eclipse.ui.startup">
+		<startup
+			class="org.eclipse.gemoc.executionframework.engine.ui.ModelingWorkbenchEarlyStartup">
+		</startup>
+	</extension>
 </plugin>

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/ModelingWorkbenchEarlyStartup.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/ModelingWorkbenchEarlyStartup.java
@@ -9,7 +9,7 @@
  *     INRIA - initial API and implementation
  *     I3S Laboratory - API update and bug fix
  *******************************************************************************/
-package org.eclipse.gemoc.executionframework.engine.ui.concurrency;
+package org.eclipse.gemoc.executionframework.engine.ui;
 
 import org.eclipse.ui.IStartup;
 

--- a/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/propertytesters/GemocXDSMLPropertyTester.java
+++ b/framework/execution_framework/plugins/org.eclipse.gemoc.executionframework.engine.ui/src/org/eclipse/gemoc/executionframework/engine/ui/propertytesters/GemocXDSMLPropertyTester.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 INRIA and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     INRIA - initial API and implementation
+ *     I3S Laboratory - API update and bug fix
+ *******************************************************************************/
+
+package org.eclipse.gemoc.executionframework.engine.ui.propertytesters;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtension;
+import org.eclipse.gemoc.xdsmlframework.api.extensions.languages.LanguageDefinitionExtensionPoint;
+
+/**
+ * Property tester for context launching menu.
+ * 
+ * Note: this PropertyTester seems to be fully activated only when the containing plugin is started, 
+ * this start may be achieved either by another plguin or using the EarlyStart 
+ */
+public class GemocXDSMLPropertyTester extends PropertyTester {
+
+	/**
+	 * name for the "is model" property
+	 */
+	private static final String PROPERTY_IS_MODEL = "isModel"; //$NON-NLS-1$
+	
+	/**
+	 * name for the "is executable domain specific model" property
+	 */
+	private static final String PROPERTY_IS_EXECUTABLE_DOMAIN_SPECIFIC_MODEL = "isExecutableDomainSpecificModel"; //$NON-NLS-1$
+	
+	
+	protected boolean isModel(IAdaptable receiver){
+		IFile modelFile = (IFile)(receiver).getAdapter(IFile.class);
+		if(modelFile !=null){
+			ResourceSet rs = new ResourceSetImpl();
+			URI modelURI = URI.createURI("platform:/resource/"+modelFile.getFullPath().toString());
+			try{
+				Resource resource = rs.getResource(modelURI, true);
+			if (resource != null) {
+				return true;
+			}
+			} catch (Exception e){
+				// not a valid model, simply ignore
+				return false;
+			}
+		}
+		return false;
+	}
+	
+	protected boolean isExecutableDomainSpecificModel(IAdaptable receiver){
+		IFile modelFile = (IFile)(receiver).getAdapter(IFile.class);
+		if(modelFile !=null){
+			
+			return existsDSMLWithFileExtension(modelFile.getFileExtension());
+		}
+		return false;
+	}
+	
+	
+	protected boolean existsDSMLWithFileExtension(String fileExtension){
+		for(LanguageDefinitionExtension lde : LanguageDefinitionExtensionPoint.getSpecifications()){
+			if( lde.getFileExtensions().contains(fileExtension)) return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Method runs the tests defined from extension points for Run As... and Debug As... menu items.
+	 * 
+	 * @see org.eclipse.core.expressions.IPropertyTester#test(java.lang.Object, java.lang.String, java.lang.Object[], java.lang.Object)
+	 * @since 3.2
+	 * @return true if the specified tests pass, false otherwise
+	 */
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+
+		if(PROPERTY_IS_MODEL.equals(property)) {
+			if (receiver instanceof IAdaptable) {
+				return isModel((IAdaptable)receiver);
+			}
+			return false;
+		}
+		if(PROPERTY_IS_EXECUTABLE_DOMAIN_SPECIFIC_MODEL.equals(property)) {
+			if (receiver instanceof IAdaptable) {
+				return isExecutableDomainSpecificModel((IAdaptable)receiver);
+			}
+			return false;
+		}
+		return false;
+	}
+	
+}

--- a/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/.classpath
+++ b/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/.classpath
@@ -25,7 +25,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -33,6 +33,19 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/framework_commons/pomfirst/org.eclipse.gemoc.xdsmlframework.api/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=17

--- a/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/.classpath
+++ b/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/.settings/org.eclipse.jdt.core.prefs
+++ b/protocols/engine_addon_protocol/pomfirst/org.eclipse.gemoc.protocols.eaop.api/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=17

--- a/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.editor/.classpath
+++ b/trace/commons/plugins/org.eclipse.gemoc.trace.commons.model.editor/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-16"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/.classpath
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/.settings/org.eclipse.jdt.core.prefs
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons.model/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/.classpath
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/.settings/org.eclipse.jdt.core.prefs
+++ b/trace/commons/pomfirst/org.eclipse.gemoc.trace.commons/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11


### PR DESCRIPTION
## Description

PropertyTester is the same in all `*gemoc.*.engine.ui` , it is now moved into 
`org.eclipse.gemoc.executionframework.engine.ui`

Similarly, the earlystartup was added to ensure that the propertytester works correctly. it has been removed from all engine.ui except `org.eclipse.gemoc.executionframework.engine.ui`

This PR also adds a shortcut launch for ALE Engine (see PR in ALE repo)

 
## Contribution to issues

Fixes https://github.com/eclipse/gemoc-studio-modeldebugging/issues/237

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->


 - PR https://github.com/eclipse/gemoc-studio-execution-java/pull/33
 - PR https://github.com/eclipse/gemoc-studio-execution-moccml/pull/80
 - PR https://github.com/eclipse/gemoc-studio-execution-ale/pull/62
